### PR TITLE
Use correct folders for configs and data instead of home folder

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -361,13 +361,13 @@ impl ConfigSet {
     }
 
     pub fn get_default_config_dir() -> PathBuf {
-        let home_dir = dirs::home_dir().expect("Unable to get home directory");
-        home_dir.join(".espanso")
+        let config_dir = dirs::config_dir().expect("Unable to get config directory");
+        config_dir.join("espanso")
     }
 
     pub fn get_default_packages_dir() -> PathBuf {
-        let espanso_dir = ConfigSet::get_default_config_dir();
-        espanso_dir.join(PACKAGES_FOLDER_NAME)
+        let data_dir = dirs::data_local_dir().expect("Unable to get data directory");
+        data_dir.join(PACKAGES_FOLDER_NAME)
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -320,13 +320,13 @@ impl ConfigSet {
     }
 
     pub fn load_default() -> Result<ConfigSet, ConfigLoadError> {
-        let espanso_dir = ConfigSet::get_default_config_dir();
+        let config_dir = ConfigSet::get_default_config_dir();
 
-        // Create the espanso dir if id doesn't exist
-        let res = create_dir_all(espanso_dir.as_path());
+        // Create the espanso dir if it doesn't exist
+        let res = create_dir_all(config_dir.as_path());
 
         if res.is_ok() {
-            let default_file = espanso_dir.join(DEFAULT_CONFIG_FILE_NAME);
+            let default_file = config_dir.join(DEFAULT_CONFIG_FILE_NAME);
 
             // If config file does not exist, create one from template
             if !default_file.exists() {
@@ -338,7 +338,7 @@ impl ConfigSet {
 
             // Create auxiliary directories
 
-            let user_config_dir = espanso_dir.join(USER_CONFIGS_FOLDER_NAME);
+            let user_config_dir = config_dir.join(USER_CONFIGS_FOLDER_NAME);
             if !user_config_dir.exists() {
                 let res = create_dir_all(user_config_dir.as_path());
                 if res.is_err() {
@@ -346,7 +346,7 @@ impl ConfigSet {
                 }
             }
 
-            let packages_dir = espanso_dir.join(PACKAGES_FOLDER_NAME);
+            let packages_dir = ConfigSet::get_default_packages_dir().join(PACKAGES_FOLDER_NAME);
             if !packages_dir.exists() {
                 let res = create_dir_all(packages_dir.as_path());
                 if res.is_err() {
@@ -354,7 +354,7 @@ impl ConfigSet {
                 }
             }
 
-            return ConfigSet::load(espanso_dir.as_path())
+            return ConfigSet::load(config_dir.as_path())
         }
 
         Err(ConfigLoadError::UnableToCreateDefaultConfig)
@@ -366,7 +366,7 @@ impl ConfigSet {
     }
 
     pub fn get_default_packages_dir() -> PathBuf {
-        let data_dir = dirs::data_local_dir().expect("Unable to get data directory");
+        let data_dir = dirs::data_local_dir().expect("Unable to get package directory");
         data_dir.join(PACKAGES_FOLDER_NAME)
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -366,7 +366,7 @@ impl ConfigSet {
     }
 
     pub fn get_default_packages_dir() -> PathBuf {
-        let data_dir = dirs::data_local_dir().expect("Unable to get package directory");
+        let data_dir = ConfigSet::get_default_config_dir();
         data_dir.join(PACKAGES_FOLDER_NAME)
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -36,7 +36,7 @@ pub trait Context {
 }
 
 pub fn get_data_dir() -> PathBuf {
-    let data_dir = dirs::data_dir().expect("Can't obtain data_dir(), terminating.");
+    let data_dir = dirs::data_local_dir().expect("Can't obtain data_dir(), terminating.");
     let espanso_dir = data_dir.join("espanso");
     create_dir_all(&espanso_dir).expect("Error creating espanso data directory");
     espanso_dir


### PR DESCRIPTION
# Summary
By applying this PR the configs will be saved in the following places:
 - Configuration
   - Linux: `$XDG_CONFIG_HOME/espanso` (e.g. `/home/user/.config/espanso`)
   - macOS: `$HOME/Library/Preferences/espanso` (e.g. `/Users/user/Library/Preferences/espanso`)
   - Windows: `{FOLDERID_RoamingAppData}\espanso` (e.g. `C:\Users\user\AppData\Roaming`)
 - Data (like lockfile and repository info)
   - Linux: `$XDG_DATA_HOME/espanso` (e.g. `/home/user/.local/share/espanso`)
   - macOS: `$HOME/Library/Application Support/espanso` (e.g. `
/Users/user/Library/Application Support/espanso`)
   - Windows: `{FOLDERID_LocalAppData}\espanso` (e.g. `C:\Users\user\AppData\Local`)

Before this change all the files would be stored at `$HOME/espanso` (e.g. `/home/user/espanso`, `/Users/user/espanso`) or `{FOLDERID_Profile}\espanso` (e.g. `C:\Users\user\espanso`)

# Considerations
 - This PR only changes the paths. This change would cause, that old installations would need to be manually adapted to this change. Perhaps there could be a way to do this automatically in packaging? We would definitely tell the user that this has been changed.
 - There may be unexpected bugs with this change. I will test this further.