### PR TITLE
only call get_config_dir() once

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -777,9 +777,12 @@ fn list_package_main(_config_set: ConfigSet, matches: &ArgMatches) {
 }
 
 fn path_main(_config_set: ConfigSet) {
-    println!("Config: {}", crate::context::get_config_dir().to_string_lossy());
-    println!("Packages: {}", crate::context::get_package_dir().to_string_lossy());
-    println!("Data: {}", crate::context::get_config_dir().to_string_lossy());
+    let config_dir = crate::context::get_config_dir().to_string_lossy());
+    let package_dir = crate::context::get_package_dir().to_string_lossy());
+
+    println!("Config: {}", &config_dir);
+    println!("Packages: {}",&package_dir);
+    println!("Data: {}", &config_dir);
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,8 +777,8 @@ fn list_package_main(_config_set: ConfigSet, matches: &ArgMatches) {
 }
 
 fn path_main(_config_set: ConfigSet) {
-    let config_dir = crate::context::get_config_dir().to_string_lossy());
-    let package_dir = crate::context::get_package_dir().to_string_lossy());
+    let config_dir = crate::context::get_config_dir().to_string_lossy();
+    let package_dir = crate::context::get_package_dir().to_string_lossy();
 
     println!("Config: {}", &config_dir);
     println!("Packages: {}",&package_dir);


### PR DESCRIPTION
This is a fix for issue #85.

Stores the output of 'get_config_dir' so that the `eprintln!` statements within are not called multiple times.