### PR TITLE
preserve the current clipboard when using the Clipboard backend.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -205,8 +205,10 @@ impl <'a, S: KeyboardManager, C: ClipboardManager, M: ConfigManager<'a>, U: UIMa
                         }
                     },
                     BackendType::Clipboard => {
+                        let previous_clipboard_content = self.clipboard_manager.get_clipboard().unwrap_or(String::from(""));
                         self.clipboard_manager.set_clipboard(&target_string);
                         self.keyboard_manager.trigger_paste(&config.paste_shortcut);
+                        self.clipboard_manager.set_clipboard(&previous_clipboard_content);
                     },
                 }
 


### PR DESCRIPTION
Store the current clipboard and restore it after the expansion has been pasted.
This prevents your current clipboard from being lost if using the Clipboard backend.