### PR TITLE
Add support for kitty terminal

### DIFF
--- a/native/liblinuxbridge/bridge.cpp
+++ b/native/liblinuxbridge/bridge.cpp
@@ -495,6 +495,8 @@ int32_t is_current_window_special() {
             return 1;
         }else if (strstr(class_buffer, "Tilix") != NULL) {  // Tilix terminal
             return 1;
+        }else if (strstr(class_buffer, "kitty") != NULL) {  // kitty terminal
+            return 1;
         }
     }
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,7 +19,7 @@ description: |
 
   * Works on Windows, macOS and Linux
   * Works with almost any program
-  * Works with Emojis 😄
+  * Works with Emojis ¯\_(ツ)_/¯
   * Works with Images
   * Date expansion support
   * Custom scripts support


### PR DESCRIPTION
Currently replacement does not work in kitty, since it needs the same special treatment as tilix. This pr simply adds the necessary workaround.