### PR TITLE
Tighten passive expansion process

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -95,6 +95,9 @@ fn default_passive_arg_delimiter() -> char {
 fn default_passive_arg_escape() -> char {
     '\\'
 }
+fn default_passive_delay() -> u64 {
+    100
+}
 fn default_passive_key() -> KeyModifier {
     KeyModifier::OFF
 }
@@ -205,6 +208,9 @@ pub struct Configs {
 
     #[serde(default = "default_passive_key")]
     pub passive_key: KeyModifier,
+
+    #[serde(default = "default_passive_delay")]
+    pub passive_delay: u64,
 
     #[serde(default = "default_enable_passive")]
     pub enable_passive: bool,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -346,10 +346,13 @@ impl<
         // In order to avoid pasting previous clipboard contents, we need to check if
         // a new clipboard was effectively copied.
         // See issue: https://github.com/federico-terzi/espanso/issues/213
-        let previous_clipboard = self.clipboard_manager.get_clipboard();
+        let previous_clipboard = self.clipboard_manager.get_clipboard().unwrap_or_default();
 
         // Sleep for a while, giving time to effectively copy the text
         std::thread::sleep(std::time::Duration::from_millis(100)); // TODO: avoid hardcoding
+
+        // Clear the clipboard, for new-content detection later
+        self.clipboard_manager.set_clipboard("");
 
         // Trigger a copy shortcut to transfer the content of the selection to the clipboard
         self.keyboard_manager.trigger_copy(&config);
@@ -360,31 +363,29 @@ impl<
         // Then get the text from the clipboard and render the match output
         let clipboard = self.clipboard_manager.get_clipboard();
 
+        // Restore original clipboard now, in case expansion doesn't happen at all
+        self.clipboard_manager.set_clipboard(&previous_clipboard);
+
         if let Some(clipboard) = clipboard {
             // Don't expand empty clipboards, as usually they are the result of an empty passive selection
             if clipboard.trim().is_empty() {
                 info!("Avoiding passive expansion, as the user didn't select anything");
             } else {
-                if let Some(previous_content) = previous_clipboard {
-                    // Because of issue #213, we need to make sure the user selected something.
-                    if clipboard == previous_content {
-                        info!("Avoiding passive expansion, as the user didn't select anything");
-                    } else {
-                        info!("Passive mode activated");
+                info!("Passive mode activated");
 
-                        let rendered = self.renderer.render_passive(&clipboard, &config);
+                let rendered = self.renderer.render_passive(&clipboard, &config);
 
-                        match rendered {
-                            RenderResult::Text(payload) => {
-                                // Paste back the result in the field
-                                self.clipboard_manager.set_clipboard(&payload);
+                match rendered {
+                    RenderResult::Text(payload) => {
+                        // Paste back the result in the field
+                        self.clipboard_manager.set_clipboard(&payload);
 
-                                std::thread::sleep(std::time::Duration::from_millis(100)); // TODO: avoid hardcoding
-                                self.keyboard_manager.trigger_paste(&config);
-                            }
-                            _ => warn!("Cannot expand passive match"),
-                        }
+                        std::thread::sleep(std::time::Duration::from_millis(100)); // TODO: avoid hardcoding
+                        self.keyboard_manager.trigger_paste(&config);
+
+                        self.clipboard_manager.set_clipboard(&previous_clipboard);
                     }
+                    _ => warn!("Cannot expand passive match"),
                 }
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -349,22 +349,22 @@ impl<
         let previous_clipboard = self.clipboard_manager.get_clipboard().unwrap_or_default();
 
         // Sleep for a while, giving time to effectively copy the text
-        std::thread::sleep(std::time::Duration::from_millis(100)); // TODO: avoid hardcoding
+        std::thread::sleep(std::time::Duration::from_millis(config.passive_delay));
 
         // Clear the clipboard, for new-content detection later
         self.clipboard_manager.set_clipboard("");
+
+        // Sleep for a while, giving time to effectively copy the text
+        std::thread::sleep(std::time::Duration::from_millis(config.passive_delay));
 
         // Trigger a copy shortcut to transfer the content of the selection to the clipboard
         self.keyboard_manager.trigger_copy(&config);
 
         // Sleep for a while, giving time to effectively copy the text
-        std::thread::sleep(std::time::Duration::from_millis(100)); // TODO: avoid hardcoding
+        std::thread::sleep(std::time::Duration::from_millis(config.passive_delay));
 
         // Then get the text from the clipboard and render the match output
         let clipboard = self.clipboard_manager.get_clipboard();
-
-        // Restore original clipboard now, in case expansion doesn't happen at all
-        self.clipboard_manager.set_clipboard(&previous_clipboard);
 
         if let Some(clipboard) = clipboard {
             // Don't expand empty clipboards, as usually they are the result of an empty passive selection
@@ -380,15 +380,18 @@ impl<
                         // Paste back the result in the field
                         self.clipboard_manager.set_clipboard(&payload);
 
-                        std::thread::sleep(std::time::Duration::from_millis(100)); // TODO: avoid hardcoding
+                        std::thread::sleep(std::time::Duration::from_millis(config.passive_delay));
                         self.keyboard_manager.trigger_paste(&config);
-
-                        self.clipboard_manager.set_clipboard(&previous_clipboard);
                     }
                     _ => warn!("Cannot expand passive match"),
                 }
             }
         }
+
+        std::thread::sleep(std::time::Duration::from_millis(config.passive_delay));
+
+        // Restore original clipboard
+        self.clipboard_manager.set_clipboard(&previous_clipboard);
 
         // Re-allow espanso to interpret actions
         self.is_injecting.store(false, Release);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -373,6 +373,9 @@ impl<
             } else {
                 info!("Passive mode activated");
 
+                // Restore original clipboard in case it's used during render
+                self.clipboard_manager.set_clipboard(&previous_clipboard);
+
                 let rendered = self.renderer.render_passive(&clipboard, &config);
 
                 match rendered {


### PR DESCRIPTION
- Don't abort if original clipboard is None (why should we?)
- Don't abort if original clipboard has the same text as that selected
- If original clipboard has text, restore that text before render
- If original clipboard has text, restore that text in case of aborted expansion

Note: will unfortunately remove non-text data (image) from clipboard if no text
is selected when passive expansion is triggered

Fixes #372

Fixes #365 (supersedes #368)

I left the hardcoded delays intact, though it's not clear exactly when they're necessary.