### PR TITLE
Add AUR Installation guide for modulo and fix information about git branch for espanso-git

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -121,7 +121,7 @@ but you can also install it manually from the [prebuilt executables](#installing
 The official way to install espanso on Arch-based systems is by using one of the AUR packages, currently maintained by [Scrumplex](https://scrumplex.net/). There are multiple options available:
 
 * [espanso](https://aur.archlinux.org/packages/espanso/) - Builds from the latest (stable) release.
-* [espanso-git](https://aur.archlinux.org/packages/espanso-git/) - Builds from latest commit ( in master branch ).
+* [espanso-git](https://aur.archlinux.org/packages/espanso-git/) - Builds from latest commit (in dev branch).
 
 When you are ready, you can install espanso with:
 
@@ -224,3 +224,4 @@ makepkg -si
 
 
 At this point, you are ready to read the [Getting Started](/docs/get-started/) tutorial.
+

--- a/install/linux.md
+++ b/install/linux.md
@@ -184,6 +184,8 @@ At this point, you should [install `modulo`](#installing-modulo) to enable the G
 
 Since version 0.7.0, espanso introduced a few gui-related features that require [modulo](https://github.com/federico-terzi/modulo) to be installed in your system. **While not strictly required, it's highly suggested to install it enable some very useful features, such as Forms.**.
 
+#### Manual installation
+
 Installing modulo is pretty straight forward, being it packaged as an AppImage. Here's the list of suggested steps:
 
 ```bash
@@ -201,5 +203,24 @@ sudo ln -s $HOME/opt/modulo.AppImage /usr/bin/modulo
 ```
 
 Note that these steps can be changed in many ways, the only requirement is that the modulo binary is available as `modulo` in the PATH.
+
+#### Installing on Manjaro / Arch
+
+Similarily to espanso itself, there are multiple ways to install modulo on Arch: You can either use the [manual method above](#manual-installation-1) or install it using the [AUR](#installing-from-aur-1) package.
+
+##### Installing from AUR
+
+The official way to install modulo on Arch-based systems is by using one of the AUR packages, currently maintained by [Scrumplex](https://scrumplex.net/). There are multiple options available:
+
+* [modulo](https://aur.archlinux.org/packages/modulo/) - Builds from the latest (stable) release.
+* [modulo-git](https://aur.archlinux.org/packages/modulo-git/) - Builds from the latest commit (in dev branch)
+
+After you chose the package you want, you can install modulo with:
+```
+git clone https://aur.archlinux.org/modulo.git
+cd modulo
+makepkg -si
+```
+
 
 At this point, you are ready to read the [Getting Started](/docs/get-started/) tutorial.


### PR DESCRIPTION
Hey there!

I packaged modulo sometime ago on the AUR, but never came around to add it to the docs. Now here you go! 

I also noticed that `espanso-git` had a notice about it using the master branch. It actually uses the dev branch to build, which you can see [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=espanso-git&id=f63db712dcf105a7081348cd1601066ce9b9f380#n3).
