### PR TITLE
Document interaction of CLI & package script

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,3 +42,14 @@ espanso match exec <trigger>
 where `<trigger>` is the match trigger.
 
 This is useful if, for example, you want to trigger an expansion from a script.
+
+### Paths
+
+Besides the [overview command](configuration#structure) `espanso path`,
+you can also output the exact paths to specific components:
+
+```
+espanso path packages # or config, data or default
+```
+
+This is useful for including [scripts in packages](packages#scripts-in-packages).

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -112,7 +112,8 @@ allowed)
 ### Scripts in packages
 
 [Script Extension](matches#script-extension) can also be added to packages.
-Use a combination of the [CLI](cli#paths)'s `espanso path packages` output
+Use a combination of the [Shell Extension](matches#shell-extension),
+the [CLI](cli#paths)'s `espanso path packages` output,
 and your package's name to automatically construct the correct path:
 
 {% raw %}
@@ -121,11 +122,9 @@ and your package's name to automatically construct the correct path:
   replace: "{{output}}"
   vars:
     - name: output
-      type: script
+      type: shell
       params:
-        args:
-          - python
-          - "$(espanso path packages)/simple-package/scripts/script.py"
+        cmd: "python "$(espanso path packages)"/simple-package/scripts/script.py'
 ```
 {% endraw %}
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -109,6 +109,26 @@ allowed)
       replace: "hello world"
     ```
 
+### Scripts in packages
+
+[Script Extension](matches#script-extension) can also be added to packages.
+Use a combination of the [CLI](cli#paths)'s `espanso path packages` output
+and your package's name to automatically construct the correct path:
+
+{% raw %}
+```yaml
+- trigger: ":pyscript"
+  replace: "{{output}}"
+  vars:
+    - name: output
+      type: script
+      params:
+        args:
+          - python
+          - "$(espanso path packages)/simple-package/scripts/script.py"
+```
+{% endraw %}
+
 #### Publishing on espanso hub
 
 After following all these steps, you can request to publish your package to [espanso hub](http://hub.espanso.org)


### PR DESCRIPTION
I realize that this might create problems, if untrusted code gets executed, but should the technical possibility of adding scripts to packages be documented?

For example in this manner?