### PR TITLE
Detect and prefer system-provided service

### DIFF
--- a/espanso/src/cli/service/linux.rs
+++ b/espanso/src/cli/service/linux.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 
 use crate::{error_eprintln, info_println, warn_eprintln};
 
-const LINUX_SERVICE_NAME: &str = "espanso";
+const LINUX_SERVICE_NAME: &str = "espanso.service";
 const LINUX_SERVICE_CONTENT: &str = include_str!("../../res/linux/systemd.service");
 #[allow(clippy::transmute_bytes_to_str)]
 const LINUX_SERVICE_FILENAME: &str = formatcp!("{}.service", LINUX_SERVICE_NAME);


### PR DESCRIPTION
```
Instead of always creating our own service file for the user, detect if
there is a service already present, and skip installing our own
service file.
```

Some distributions might choose to package the user service as well. For example the AUR packages take the template in the repo, replace the binary path and install it to `/usr/lib/systemd/user/espanso.service`. To keep the systemd environment of users of those packages clean, we should first check if a service already exists.