### PR TITLE
Add WinGet Releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,15 @@ jobs:
         run: |
           gh release upload ${{ needs.extract-version.outputs.espanso_version }} target/windows/installer/Espanso-Win-Installer-x86_64.exe target/windows/Espanso-Win-Portable-x86_64.zip target/windows/installer/Espanso-Win-Installer-x86_64.exe.sha256.txt target/windows/Espanso-Win-Portable-x86_64.zip.sha256.txt
   
+  windows-publish-winget:
+    needs: [ windows ]
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: Espanso.Espanso
+          token: ${{ secrets.WINGET_TOKEN }}
+  
   linux-x11:
     needs: ["extract-version", "create-release"]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
     needs: [ windows ]
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: Espanso.Espanso
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
           gh release upload ${{ needs.extract-version.outputs.espanso_version }} target/windows/installer/Espanso-Win-Installer-x86_64.exe target/windows/Espanso-Win-Portable-x86_64.zip target/windows/installer/Espanso-Win-Installer-x86_64.exe.sha256.txt target/windows/Espanso-Win-Portable-x86_64.zip.sha256.txt
   
   windows-publish-winget:
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: [ windows ]
     runs-on: windows-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
     needs: [ windows ]
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: Espanso.Espanso
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This pull request adds a workflow that automatically publishes espanso to WinGet every release. *Please do not merge this pull request without reading the below and making the required changes* :)

- `token: ${{ secrets.WINGET_TOKEN }}`

This is the bit that will require action from the person whose account will be used for the pull requests (a member of the espanso GitHub organisation). This is a GitHub token with which the action will authenticate with GitHub and create a pull request on the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.

To do this, you will need to:

1. Create a Personal Access Token (PAT) with `public_repo` scope.

![image](https://user-images.githubusercontent.com/74878137/192060610-f5e3f925-bc6d-4dab-98a8-4a29e82449c5.png)

2. Create a repository secret containing the token. **Super important: call this token: `WINGET_TOKEN`**.
See [using encrypted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) for more details.

</br>

**Finally, a fork of [winget-pkgs](https://github.com/microsoft/winget-pkgs) needs to be created under the espanso organisation. Please do not delete the fork after a pull request has been merged as the action will use that fork for making a branch and merging it with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every espanso release.**

If you would like to read about this action further, the source code and documentation are [here](https://github.com/vedantmgoyal2009/winget-releaser).

Requesting review from @vedantmgoyal2009
