### PR TITLE
fix(inject): attach modifiers state to the next record on x11

### DIFF
--- a/espanso-inject/src/x11/default/mod.rs
+++ b/espanso-inject/src/x11/default/mod.rs
@@ -354,16 +354,15 @@ impl X11DefaultInjector {
     let mut current_state = 0u32;
     for record in original_records {
       let mut current_record = *record;
+      current_record.main.state = current_state;
+      records.push(current_record);
 
-      // Render the state by applying the modifiers
+      // Calculate the state for the next record by applying the modifiers
       for (mod_index, modifier) in modifiers_codes.iter().enumerate() {
         if modifier.contains(&(record.main.code as u8)) {
           current_state |= 1 << mod_index;
         }
       }
-
-      current_record.main.state = current_state;
-      records.push(current_record);
     }
 
     records


### PR DESCRIPTION
When pressing Ctrl+Shift+v, previously the injected key events would be:
- `Ctrl` key with modifier state for Ctrl
- `Shift` key with modifier state for Ctrl & Shift
- `v` key with modifier state for Ctrl & Shift

Whereas manually typing the keys would give the following key events (tested in `xev -event keyboard`):
- `Ctrl` key with no modifiers
- `Shift` key with modifier state for Ctrl
- `v` key with modifier state for Ctrl & Shift

Meaning that the key event state represents the modifiers that exist at a given moment, not the new state with the current modifier being pressed.

This PR changes the behavior to work as if the keys were types manually, with the modifiers state being applied to the _next_ record, not the current one.

---
For some reason apps seems to handle/correct that inconsistency well, but I think it's doesn't hurt to resolve it cleanly.

I noticed this while trying to debug why [Espanso wasn't working on Wezterm without `disable_x11_fast_inject: true`](https://github.com/wez/wezterm/issues/3840#issuecomment-1677974127) where the `v` key is received by Wezterm without modifier state (seems to be another problem in Wezterm though).