### PR TITLE
fix(detect): update sctk dependency to fix crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,12 +172,15 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
+checksum = "595eb0438b3c6d262395fe30e6de9a61beb57ea56290b00a07f227fe6e20cbf2"
 dependencies = [
  "log",
- "nix 0.22.3",
+ "nix",
+ "slotmap",
+ "thiserror",
+ "vec_map",
 ]
 
 [[package]]
@@ -1546,9 +1549,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.3.1"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -1709,19 +1712,6 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "nix"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
-dependencies = [
- "bitflags 1.2.1",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -2545,6 +2535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,9 +2551,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.15.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
+checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
 dependencies = [
  "bitflags 1.2.1",
  "calloop",
@@ -2562,7 +2561,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix 0.22.3",
+ "nix",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
@@ -3158,7 +3157,7 @@ dependencies = [
  "bitflags 1.2.1",
  "downcast-rs",
  "libc",
- "nix 0.24.2",
+ "nix",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -3171,7 +3170,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
- "nix 0.24.2",
+ "nix",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -3183,7 +3182,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
- "nix 0.24.2",
+ "nix",
  "wayland-client",
  "xcursor",
 ]

--- a/espanso-detect/Cargo.toml
+++ b/espanso-detect/Cargo.toml
@@ -24,7 +24,7 @@ widestring = "0.4.3"
 [target.'cfg(target_os="linux")'.dependencies]
 libc = "0.2.85"
 scopeguard = "1.1.0"
-sctk = { package = "smithay-client-toolkit", version = "0.15.4", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.16.1", optional = true }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/espanso-detect/src/evdev/sync/wayland.rs
+++ b/espanso-detect/src/evdev/sync/wayland.rs
@@ -67,10 +67,7 @@ pub fn get_modifiers_state() -> Result<Option<super::ModifiersState>> {
    * Keyboard initialization
    */
 
-  let mut seats = Vec::<(
-    String,
-    Option<(wl_keyboard::WlKeyboard, calloop::RegistrationToken)>,
-  )>::new();
+  let mut seats = Vec::<(String, Option<wl_keyboard::WlKeyboard>)>::new();
 
   // first process already existing seats
   for seat in env.get_all_seats() {
@@ -89,8 +86,8 @@ pub fn get_modifiers_state() -> Result<Option<super::ModifiersState>> {
           RepeatKind::System,
           move |event, _, _| keyboard_event_handler(event, &result_clone),
         ) {
-          Ok((kbd, repeat_source)) => {
-            seats.push((name, Some((kbd, repeat_source))));
+          Ok(kbd) => {
+            seats.push((name, Some(kbd)));
           }
           Err(e) => {
             error!("Failed to map keyboard on seat {} : {:?}.", name, e);
@@ -127,8 +124,8 @@ pub fn get_modifiers_state() -> Result<Option<super::ModifiersState>> {
           RepeatKind::System,
           move |event, _, _| keyboard_event_handler(event, &result_clone),
         ) {
-          Ok((kbd, repeat_source)) => {
-            *opt_kbd = Some((kbd, repeat_source));
+          Ok(kbd) => {
+            *opt_kbd = Some(kbd);
           }
           Err(e) => {
             eprintln!(
@@ -138,10 +135,9 @@ pub fn get_modifiers_state() -> Result<Option<super::ModifiersState>> {
           }
         }
       }
-    } else if let Some((kbd, source)) = opt_kbd.take() {
+    } else if let Some(kbd) = opt_kbd.take() {
       // the keyboard has been removed, cleanup
       kbd.release();
-      loop_handle.remove(source);
     }
   });
 


### PR DESCRIPTION
Integrates the fix from smithay-client-toolkit [PR 406](https://github.com/Smithay/client-toolkit/pull/406).

This should resolve #1768 and #1750.

## Testing?
Compiled with patched smithay-client-toolkit package and confirmed espanso runs normally under Hyprland v0.33.1.
## Anything Else?
This is my very first PR, apologies if information is missing. 

I am unsure how the smithay-client-toolkit dependency should ultimately be patched. Currently Cargo.toml points to the fork I made of sctk. I tried naively updating to 16.1 which should include this fix, but there are breaking changes which cause the build to fail. 

Thanks!