### PR TITLE
Improve code quality opting-in some `clippy` pedantic lints

### DIFF
--- a/espanso-clipboard/src/win32/mod.rs
+++ b/espanso-clipboard/src/win32/mod.rs
@@ -106,7 +106,7 @@ fn generate_html_descriptor(html: &str) -> String {
   // For more information, look here:
   // https://docs.microsoft.com/en-us/windows/win32/dataxchg/html-clipboard-format
   // https://docs.microsoft.com/en-za/troubleshoot/cpp/add-html-code-clipboard
-  let content = format!("<!--StartFragment-->{}<!--EndFragment-->", html);
+  let content = format!("<!--StartFragment-->{html}<!--EndFragment-->");
 
   let tokens = [
     "Version:0.9",

--- a/espanso-config/src/config/parse/yaml.rs
+++ b/espanso-config/src/config/parse/yaml.rs
@@ -360,6 +360,6 @@ mod tests {
         filter_os: Some("test7".to_string()),
         filter_title: Some("test8".to_string()),
       }
-    )
+    );
   }
 }

--- a/espanso-config/src/config/path.rs
+++ b/espanso-config/src/config/path.rs
@@ -101,7 +101,7 @@ pub mod tests {
 
       let result = calculate_paths(
         base,
-        vec![
+        [
           "**/*.yml".to_string(),
           "match/sub/*.yml".to_string(),
           // Invalid path
@@ -135,7 +135,7 @@ pub mod tests {
       let sub_file = sub_dir.join("sub.yml");
       std::fs::write(&sub_file, "test").unwrap();
 
-      let result = calculate_paths(base, vec!["match/sub/../sub/*.yml".to_string()].iter());
+      let result = calculate_paths(base, ["match/sub/../sub/*.yml".to_string()].iter());
 
       let mut expected = HashSet::new();
       expected.insert(sub_file.to_string_lossy().to_string());
@@ -161,7 +161,7 @@ pub mod tests {
 
       let result = calculate_paths(
         base,
-        vec![
+        [
           format!("{}/**/*.yml", base.to_string_lossy()),
           format!("{}/match/sub/*.yml", base.to_string_lossy()),
           // Invalid path

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -820,7 +820,7 @@ mod tests {
 
       let config = ResolvedConfig::load(&config_file, None).unwrap();
 
-      *result_ref = config.is_match(app)
+      *result_ref = config.is_match(app);
     });
     result
   }

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -517,7 +517,7 @@ mod tests {
       ResolvedConfig::aggregate_includes(&ParsedConfig {
         ..Default::default()
       }),
-      vec!["../match/**/[!_]*.yml".to_string(),]
+      ["../match/**/[!_]*.yml".to_string()]
         .iter()
         .cloned()
         .collect::<HashSet<_>>()
@@ -542,7 +542,7 @@ mod tests {
         includes: Some(vec!["custom/*.yml".to_string()]),
         ..Default::default()
       }),
-      vec![
+      [
         "../match/**/[!_]*.yml".to_string(),
         "custom/*.yml".to_string()
       ]
@@ -559,7 +559,7 @@ mod tests {
         extra_includes: Some(vec!["custom/*.yml".to_string()]),
         ..Default::default()
       }),
-      vec![
+      [
         "../match/**/[!_]*.yml".to_string(),
         "custom/*.yml".to_string()
       ]
@@ -577,7 +577,7 @@ mod tests {
         extra_includes: Some(vec!["custom/*.yml".to_string()]),
         ..Default::default()
       }),
-      vec![
+      [
         "../match/**/[!_]*.yml".to_string(),
         "custom/*.yml".to_string(),
         "sub/*.yml".to_string()
@@ -617,7 +617,7 @@ mod tests {
         excludes: Some(vec!["custom/*.yml".to_string()]),
         ..Default::default()
       }),
-      vec!["custom/*.yml".to_string()]
+      ["custom/*.yml".to_string()]
         .iter()
         .cloned()
         .collect::<HashSet<_>>()
@@ -631,7 +631,7 @@ mod tests {
         extra_excludes: Some(vec!["custom/*.yml".to_string()]),
         ..Default::default()
       }),
-      vec!["custom/*.yml".to_string()]
+      ["custom/*.yml".to_string()]
         .iter()
         .cloned()
         .collect::<HashSet<_>>()
@@ -646,7 +646,7 @@ mod tests {
         extra_excludes: Some(vec!["custom/*.yml".to_string()]),
         ..Default::default()
       }),
-      vec!["custom/*.yml".to_string(), "sub/*.yml".to_string()]
+      ["custom/*.yml".to_string(), "sub/*.yml".to_string()]
         .iter()
         .cloned()
         .collect::<HashSet<_>>()

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -178,15 +178,15 @@ impl Config for ResolvedConfig {
       Some("ctrl") => Some(ToggleKey::Ctrl),
       Some("alt") => Some(ToggleKey::Alt),
       Some("shift") => Some(ToggleKey::Shift),
-      Some("meta") | Some("cmd") => Some(ToggleKey::Meta),
+      Some("meta" | "cmd") => Some(ToggleKey::Meta),
       Some("right_ctrl") => Some(ToggleKey::RightCtrl),
       Some("right_alt") => Some(ToggleKey::RightAlt),
       Some("right_shift") => Some(ToggleKey::RightShift),
-      Some("right_meta") | Some("right_cmd") => Some(ToggleKey::RightMeta),
+      Some("right_meta" | "right_cmd") => Some(ToggleKey::RightMeta),
       Some("left_ctrl") => Some(ToggleKey::LeftCtrl),
       Some("left_alt") => Some(ToggleKey::LeftAlt),
       Some("left_shift") => Some(ToggleKey::LeftShift),
-      Some("left_meta") | Some("left_cmd") => Some(ToggleKey::LeftMeta),
+      Some("left_meta" | "left_cmd") => Some(ToggleKey::LeftMeta),
       Some("off") => None,
       None => None,
       err => {
@@ -269,7 +269,7 @@ impl Config for ResolvedConfig {
 
   fn search_trigger(&self) -> Option<String> {
     match self.parsed.search_trigger.as_deref() {
-      Some("OFF") | Some("off") => None,
+      Some("OFF" | "off") => None,
       Some(x) => Some(x.to_string()),
       None => None,
     }
@@ -277,7 +277,7 @@ impl Config for ResolvedConfig {
 
   fn search_shortcut(&self) -> Option<String> {
     match self.parsed.search_shortcut.as_deref() {
-      Some("OFF") | Some("off") => None,
+      Some("OFF" | "off") => None,
       Some(x) => Some(x.to_string()),
       None => Some("ALT+SPACE".to_string()),
     }

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -448,19 +448,19 @@ impl ResolvedConfig {
     if config.use_standard_includes.is_none() || config.use_standard_includes.unwrap() {
       STANDARD_INCLUDES.iter().for_each(|include| {
         includes.insert(include.to_string());
-      })
+      });
     }
 
     if let Some(yaml_includes) = config.includes.as_ref() {
       yaml_includes.iter().for_each(|include| {
         includes.insert(include.to_string());
-      })
+      });
     };
 
     if let Some(extra_includes) = config.extra_includes.as_ref() {
       extra_includes.iter().for_each(|include| {
         includes.insert(include.to_string());
-      })
+      });
     };
 
     includes
@@ -472,13 +472,13 @@ impl ResolvedConfig {
     if let Some(yaml_excludes) = config.excludes.as_ref() {
       yaml_excludes.iter().for_each(|exclude| {
         excludes.insert(exclude.to_string());
-      })
+      });
     }
 
     if let Some(extra_excludes) = config.extra_excludes.as_ref() {
       extra_excludes.iter().for_each(|exclude| {
         excludes.insert(exclude.to_string());
-      })
+      });
     }
 
     excludes

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -455,13 +455,13 @@ impl ResolvedConfig {
       yaml_includes.iter().for_each(|include| {
         includes.insert(include.to_string());
       })
-    }
+    };
 
     if let Some(extra_includes) = config.extra_includes.as_ref() {
       extra_includes.iter().for_each(|include| {
         includes.insert(include.to_string());
       })
-    }
+    };
 
     includes
   }

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -130,7 +130,7 @@ impl Config for ResolvedConfig {
       .parsed
       .backend
       .as_deref()
-      .map(|b| b.to_lowercase())
+      .map(str::to_lowercase)
       .as_deref()
     {
       Some("clipboard") => Backend::Clipboard,
@@ -172,7 +172,7 @@ impl Config for ResolvedConfig {
       .parsed
       .toggle_key
       .as_deref()
-      .map(|key| key.to_lowercase())
+      .map(str::to_lowercase)
       .as_deref()
     {
       Some("ctrl") => Some(ToggleKey::Ctrl),

--- a/espanso-config/src/config/store.rs
+++ b/espanso-config/src/config/store.rs
@@ -37,7 +37,7 @@ impl ConfigStore for DefaultConfigStore {
 
   fn active(&self, app: &super::AppProperties) -> Arc<dyn super::Config> {
     // Find a custom config that matches or fallback to the default one
-    for custom in self.customs.iter() {
+    for custom in &self.customs {
       if custom.is_match(app) {
         return Arc::clone(custom);
       }
@@ -48,7 +48,7 @@ impl ConfigStore for DefaultConfigStore {
   fn configs(&self) -> Vec<Arc<dyn Config>> {
     let mut configs = vec![Arc::clone(&self.default)];
 
-    for custom in self.customs.iter() {
+    for custom in &self.customs {
       configs.push(Arc::clone(custom));
     }
 
@@ -60,7 +60,7 @@ impl ConfigStore for DefaultConfigStore {
     let mut paths = HashSet::new();
 
     paths.extend(self.default().match_paths().iter().cloned());
-    for custom in self.customs.iter() {
+    for custom in &self.customs {
       paths.extend(custom.match_paths().iter().cloned());
     }
 

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -412,7 +412,7 @@ impl LegacyConfig {
         Err(e) => Err(ConfigLoadError::InvalidYAML(path.to_owned(), e.to_string())),
       }
     } else {
-      eprintln!("Error: Cannot load file {:?}", path);
+      eprintln!("Error: Cannot load file {path:?}");
       Err(ConfigLoadError::FileNotFound)
     }
   }
@@ -615,7 +615,7 @@ impl LegacyConfigSet {
           }
         }
         Err(e) => {
-          eprintln!("Warning: Unable to read config file: {}", e);
+          eprintln!("Warning: Unable to read config file: {e}");
         }
       }
 
@@ -725,8 +725,7 @@ impl LegacyConfigSet {
       if item.starts_with(previous) {
         has_conflicts = true;
         eprintln!(
-          "Warning: trigger '{}' is conflicting with '{}' and may not behave as intended",
-          item, previous
+          "Warning: trigger '{item}' is conflicting with '{previous}' and may not behave as intended"
         );
       }
     }

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -30,6 +30,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::string::ToString;
 use walkdir::{DirEntry, WalkDir};
 
 pub const DEFAULT_CONFIG_FILE_NAME: &str = "default.yml";
@@ -494,7 +495,7 @@ fn triggers_for_match(m: &Value) -> Vec<String> {
   if let Some(triggers) = m.get("triggers").and_then(|v| v.as_sequence()) {
     triggers
       .iter()
-      .filter_map(|v| v.as_str().map(|s| s.to_string()))
+      .filter_map(|v| v.as_str().map(ToString::to_string))
       .collect()
   } else if let Some(trigger) = m.get("trigger").and_then(|v| v.as_str()) {
     vec![trigger.to_string()]

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -422,9 +422,9 @@ impl LegacyConfig {
     // Merge matches
     let mut merged_matches = new_config.matches;
     let mut match_trigger_set = HashSet::new();
-    merged_matches.iter().for_each(|m| {
+    for m in merged_matches.iter() {
       match_trigger_set.extend(triggers_for_match(m));
-    });
+    }
     let parent_matches: Vec<Value> = self
       .matches
       .iter()
@@ -442,9 +442,9 @@ impl LegacyConfig {
     // Merge global variables
     let mut merged_global_vars = new_config.global_vars;
     let mut vars_name_set = HashSet::new();
-    merged_global_vars.iter().for_each(|m| {
+    for m in merged_global_vars.iter() {
       vars_name_set.insert(name_for_global_var(m));
-    });
+    }
     let parent_vars: Vec<Value> = self
       .global_vars
       .iter()

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -422,7 +422,7 @@ impl LegacyConfig {
     // Merge matches
     let mut merged_matches = new_config.matches;
     let mut match_trigger_set = HashSet::new();
-    for m in merged_matches.iter() {
+    for m in &merged_matches {
       match_trigger_set.extend(triggers_for_match(m));
     }
     let parent_matches: Vec<Value> = self
@@ -442,7 +442,7 @@ impl LegacyConfig {
     // Merge global variables
     let mut merged_global_vars = new_config.global_vars;
     let mut vars_name_set = HashSet::new();
-    for m in merged_global_vars.iter() {
+    for m in &merged_global_vars {
       vars_name_set.insert(name_for_global_var(m));
     }
     let parent_vars: Vec<Value> = self
@@ -654,7 +654,7 @@ impl LegacyConfigSet {
     let mut specific = configs[1..].to_vec();
 
     // Add default entries to specific configs when needed
-    for config in specific.iter_mut() {
+    for config in &mut specific {
       if !config.exclude_default_entries {
         config.merge_no_overwrite(&default);
       }
@@ -704,7 +704,7 @@ impl LegacyConfigSet {
 
     let mut has_conflicts = Self::list_has_conflicts(&sorted_triggers);
 
-    for s in specific.iter() {
+    for s in specific {
       let mut specific_triggers: Vec<String> =
         s.matches.iter().flat_map(triggers_for_match).collect();
       specific_triggers.sort();

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -1019,7 +1019,7 @@ mod tests {
     assert_eq!(
       config_set.unwrap_err(),
       ConfigLoadError::InvalidParameter(user_defined_path)
-    )
+    );
   }
 
   #[test]
@@ -1039,7 +1039,7 @@ mod tests {
     assert_eq!(
       config_set.unwrap().specific[0].name,
       user_defined_path.to_str().unwrap_or_default()
-    )
+    );
   }
 
   #[test]
@@ -1067,7 +1067,7 @@ mod tests {
     assert!(matches!(
       &config_set.unwrap_err(),
       &ConfigLoadError::NameDuplicate(_)
-    ))
+    ));
   }
 
   #[test]

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -44,13 +44,13 @@ fn default_parent() -> String {
   "self".to_owned()
 }
 fn default_filter_title() -> String {
-  "".to_owned()
+  String::new()
 }
 fn default_filter_class() -> String {
-  "".to_owned()
+  String::new()
 }
 fn default_filter_exec() -> String {
-  "".to_owned()
+  String::new()
 }
 fn default_log_level() -> i32 {
   0

--- a/espanso-config/src/legacy/mod.rs
+++ b/espanso-config/src/legacy/mod.rs
@@ -90,7 +90,7 @@ fn split_config(config: LegacyConfig) -> (LegacyInteropConfig, LegacyMatchGroup)
     .filter_map(|var| {
       let var: YAMLVariable = serde_yaml::from_value(var.clone()).ok()?;
       let (var, warnings) = try_convert_into_variable(var, true).ok()?;
-      for warning in warnings.into_iter() {
+      for warning in warnings {
         warn!("{}", warning);
       }
       Some(var)
@@ -103,7 +103,7 @@ fn split_config(config: LegacyConfig) -> (LegacyInteropConfig, LegacyMatchGroup)
     .filter_map(|var| {
       let m: YAMLMatch = serde_yaml::from_value(var.clone()).ok()?;
       let (m, warnings) = try_convert_into_match(m, true).ok()?;
-      for warning in warnings.into_iter() {
+      for warning in warnings {
         warn!("{}", warning);
       }
       Some(m)

--- a/espanso-config/src/legacy/mod.rs
+++ b/espanso-config/src/legacy/mod.rs
@@ -184,20 +184,20 @@ impl From<config::LegacyConfig> for LegacyInteropConfig {
       config: config.clone(),
       name: config.name.clone(),
       match_paths: vec![config.name],
-      filter_title: if !config.filter_title.is_empty() {
+      filter_title: if config.filter_title.is_empty() {
+        None
+      } else {
         Regex::new(&config.filter_title).ok()
-      } else {
-        None
       },
-      filter_class: if !config.filter_class.is_empty() {
+      filter_class: if config.filter_class.is_empty() {
+        None
+      } else {
         Regex::new(&config.filter_class).ok()
-      } else {
-        None
       },
-      filter_exec: if !config.filter_exec.is_empty() {
-        Regex::new(&config.filter_exec).ok()
-      } else {
+      filter_exec: if config.filter_exec.is_empty() {
         None
+      } else {
+        Regex::new(&config.filter_exec).ok()
       },
     }
   }
@@ -437,10 +437,10 @@ impl LegacyMatchStore {
 
 impl MatchStore for LegacyMatchStore {
   fn query(&self, paths: &[String]) -> MatchSet {
-    let group = if !paths.is_empty() {
-      self.groups.get(&paths[0])
-    } else {
+    let group = if paths.is_empty() {
       None
+    } else {
+      self.groups.get(&paths[0])
     };
 
     if let Some(group) = group {

--- a/espanso-config/src/legacy/mod.rs
+++ b/espanso-config/src/legacy/mod.rs
@@ -90,9 +90,9 @@ fn split_config(config: LegacyConfig) -> (LegacyInteropConfig, LegacyMatchGroup)
     .filter_map(|var| {
       let var: YAMLVariable = serde_yaml::from_value(var.clone()).ok()?;
       let (var, warnings) = try_convert_into_variable(var, true).ok()?;
-      warnings.into_iter().for_each(|warning| {
+      for warning in warnings.into_iter() {
         warn!("{}", warning);
-      });
+      }
       Some(var)
     })
     .collect();
@@ -103,9 +103,9 @@ fn split_config(config: LegacyConfig) -> (LegacyInteropConfig, LegacyMatchGroup)
     .filter_map(|var| {
       let m: YAMLMatch = serde_yaml::from_value(var.clone()).ok()?;
       let (m, warnings) = try_convert_into_match(m, true).ok()?;
-      warnings.into_iter().for_each(|warning| {
+      for warning in warnings.into_iter() {
         warn!("{}", warning);
-      });
+      }
       Some(m)
     })
     .collect();

--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -210,7 +210,7 @@ pub fn try_convert_into_match(
       for yaml_var in yaml_match.vars.unwrap_or_default() {
         let (var, var_warnings) =
           try_convert_into_variable(yaml_var.clone(), use_compatibility_mode)
-            .with_context(|| format!("failed to load variable: {:?}", yaml_var))?;
+            .with_context(|| format!("failed to load variable: {yaml_var:?}"))?;
         warnings.extend(var_warnings);
         vars.push(var);
       }
@@ -233,13 +233,13 @@ pub fn try_convert_into_match(
           VAR_REGEX
             .replace_all(&form_layout, |caps: &Captures| {
               let var_name = caps.get(1).unwrap().as_str();
-              format!("{{{{form1.{}}}}}", var_name)
+              format!("{{{{form1.{var_name}}}}}")
             })
             .to_string(),
           VAR_REGEX
             .replace_all(&form_layout, |caps: &Captures| {
               let var_name = caps.get(1).unwrap().as_str();
-              format!("[[{}]]", var_name)
+              format!("[[{var_name}]]")
             })
             .to_string(),
         )
@@ -248,7 +248,7 @@ pub fn try_convert_into_match(
           FORM_CONTROL_REGEX
             .replace_all(&form_layout, |caps: &Captures| {
               let var_name = caps.get(1).unwrap().as_str();
-              format!("{{{{form1.{}}}}}", var_name)
+              format!("{{{{form1.{var_name}}}}}")
             })
             .to_string(),
           form_layout,

--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -377,7 +377,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -401,7 +401,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -428,7 +428,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -454,7 +454,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -480,7 +480,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -506,7 +506,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -630,7 +630,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -667,7 +667,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -706,7 +706,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -744,7 +744,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -790,7 +790,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -824,7 +824,7 @@ mod tests {
         }),
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -896,7 +896,7 @@ mod tests {
             ..Default::default()
           }],
         }
-      )
+      );
     });
   }
 
@@ -916,6 +916,6 @@ mod tests {
 
       let importer = YAMLImporter::new();
       assert!(importer.load_group(&base_file).is_err());
-    })
+    });
   }
 }

--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -104,10 +104,10 @@ impl Importer for YAMLImporter {
         .context("failed to resolve YAML match group imports")?;
     non_fatal_errors.extend(import_errors);
 
-    let non_fatal_error_set = if !non_fatal_errors.is_empty() {
-      Some(NonFatalErrorSet::new(path, non_fatal_errors))
-    } else {
+    let non_fatal_error_set = if non_fatal_errors.is_empty() {
       None
+    } else {
+      Some(NonFatalErrorSet::new(path, non_fatal_errors))
     };
 
     Ok((

--- a/espanso-config/src/matches/group/path.rs
+++ b/espanso-config/src/matches/group/path.rs
@@ -47,7 +47,7 @@ pub fn resolve_imports(
 
   let mut non_fatal_errors = Vec::new();
 
-  for import in imports.iter() {
+  for import in imports {
     let import_path = PathBuf::from(import);
 
     // Absolute or relative import

--- a/espanso-config/src/matches/group/path.rs
+++ b/espanso-config/src/matches/group/path.rs
@@ -63,13 +63,13 @@ pub fn resolve_imports(
     {
       Ok(canonical_path) => {
         if canonical_path.exists() && canonical_path.is_file() {
-          paths.push(canonical_path)
+          paths.push(canonical_path);
         } else {
           // Best effort imports
           non_fatal_errors.push(ErrorRecord::error(anyhow!(
             "unable to resolve import at path: {:?}",
             canonical_path
-          )))
+          )));
         }
       }
       Err(error) => non_fatal_errors.push(ErrorRecord::error(error)),

--- a/espanso-config/src/matches/group/path.rs
+++ b/espanso-config/src/matches/group/path.rs
@@ -36,8 +36,7 @@ pub fn resolve_imports(
     } else {
       return Err(
         ResolveImportError::Failed(format!(
-          "unable to resolve imports for match group starting from current path: {:?}",
-          group_path
+          "unable to resolve imports for match group starting from current path: {group_path:?}"
         ))
         .into(),
       );
@@ -59,7 +58,7 @@ pub fn resolve_imports(
     };
 
     match dunce::canonicalize(&full_path)
-      .with_context(|| format!("unable to canonicalize import path: {:?}", full_path))
+      .with_context(|| format!("unable to canonicalize import path: {full_path:?}"))
     {
       Ok(canonical_path) => {
         if canonical_path.exists() && canonical_path.is_file() {

--- a/espanso-config/src/matches/mod.rs
+++ b/espanso-config/src/matches/mod.rs
@@ -73,7 +73,7 @@ impl Match {
     self
       .search_terms
       .iter()
-      .map(|term| term.as_str())
+      .map(String::as_str)
       .chain(self.cause.search_terms())
       .collect()
   }
@@ -93,7 +93,7 @@ impl MatchCause {
   // TODO: test
   pub fn description(&self) -> Option<&str> {
     if let MatchCause::Trigger(trigger_cause) = &self {
-      trigger_cause.triggers.first().map(|s| s.as_str())
+      trigger_cause.triggers.first().map(String::as_str)
     } else {
       None
     }
@@ -114,7 +114,7 @@ impl MatchCause {
 
   pub fn search_terms(&self) -> Vec<&str> {
     if let MatchCause::Trigger(trigger_cause) = &self {
-      trigger_cause.triggers.iter().map(|s| s.as_str()).collect()
+      trigger_cause.triggers.iter().map(String::as_str).collect()
     } else {
       vec![]
     }

--- a/espanso-config/src/matches/store/default.rs
+++ b/espanso-config/src/matches/store/default.rs
@@ -85,7 +85,7 @@ fn load_match_groups_recursively(
     if !groups.contains_key(path) {
       let group_path = PathBuf::from(path);
       match MatchGroup::load(&group_path)
-        .with_context(|| format!("unable to load match group {:?}", group_path))
+        .with_context(|| format!("unable to load match group {group_path:?}"))
       {
         Ok((group, non_fatal_error_set)) => {
           let imports = group.imports.clone();

--- a/espanso-config/src/matches/store/default.rs
+++ b/espanso-config/src/matches/store/default.rs
@@ -81,7 +81,7 @@ fn load_match_groups_recursively(
   paths: &[String],
   non_fatal_error_sets: &mut Vec<NonFatalErrorSet>,
 ) {
-  for path in paths.iter() {
+  for path in paths {
     if !groups.contains_key(path) {
       let group_path = PathBuf::from(path);
       match MatchGroup::load(&group_path)
@@ -114,7 +114,7 @@ fn query_matches_for_paths<'a>(
   global_vars: &mut Vec<&'a Variable>,
   paths: &[String],
 ) {
-  for path in paths.iter() {
+  for path in paths {
     if !visited_paths.contains(path) {
       visited_paths.insert(path.clone());
 
@@ -129,14 +129,14 @@ fn query_matches_for_paths<'a>(
           &group.imports,
         );
 
-        for m in group.matches.iter() {
+        for m in &group.matches {
           if !visited_matches.contains(&m.id) {
             matches.push(m);
             visited_matches.insert(m.id);
           }
         }
 
-        for var in group.global_vars.iter() {
+        for var in &group.global_vars {
           if !visited_global_vars.contains(&var.id) {
             global_vars.push(var);
             visited_global_vars.insert(var.id);

--- a/espanso-detect/src/evdev/mod.rs
+++ b/espanso-detect/src/evdev/mod.rs
@@ -86,7 +86,7 @@ pub struct EVDEVSource {
 
 #[allow(clippy::new_without_default)]
 impl EVDEVSource {
-  pub fn new(options: SourceCreationOptions) -> EVDEVSource {
+  pub fn new(options: &SourceCreationOptions) -> EVDEVSource {
     let mut modifiers_map = HashMap::new();
     modifiers_map.insert("ctrl".to_string(), KEY_CTRL + EVDEV_OFFSET);
     modifiers_map.insert("shift".to_string(), KEY_SHIFT + EVDEV_OFFSET);

--- a/espanso-detect/src/evdev/mod.rs
+++ b/espanso-detect/src/evdev/mod.rs
@@ -86,7 +86,7 @@ pub struct EVDEVSource {
 
 #[allow(clippy::new_without_default)]
 impl EVDEVSource {
-  pub fn new(options: &SourceCreationOptions) -> EVDEVSource {
+  pub fn new(options: SourceCreationOptions) -> EVDEVSource {
     let mut modifiers_map = HashMap::new();
     modifiers_map.insert("ctrl".to_string(), KEY_CTRL + EVDEV_OFFSET);
     modifiers_map.insert("shift".to_string(), KEY_SHIFT + EVDEV_OFFSET);

--- a/espanso-detect/src/hotkey/keys.rs
+++ b/espanso-detect/src/hotkey/keys.rs
@@ -210,7 +210,7 @@ impl Display for ShortcutKey {
       ShortcutKey::Numpad7 => write!(f, "NUMPAD7"),
       ShortcutKey::Numpad8 => write!(f, "NUMPAD8"),
       ShortcutKey::Numpad9 => write!(f, "NUMPAD9"),
-      ShortcutKey::Raw(code) => write!(f, "RAW({})", code),
+      ShortcutKey::Raw(code) => write!(f, "RAW({code})"),
     }
   }
 }

--- a/espanso-detect/src/hotkey/mod.rs
+++ b/espanso-detect/src/hotkey/mod.rs
@@ -53,9 +53,9 @@ impl HotKey {
       match key {
         Some(key) => {
           if MODIFIERS.contains(&key) {
-            modifiers.push(key)
+            modifiers.push(key);
           } else {
-            main_key = Some(key)
+            main_key = Some(key);
           }
         }
         None => return Err(HotKeyError::InvalidKey(token).into()),

--- a/espanso-detect/src/hotkey/mod.rs
+++ b/espanso-detect/src/hotkey/mod.rs
@@ -96,7 +96,7 @@ impl HotKey {
 
 impl Display for HotKey {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    let str_modifiers: Vec<String> = self.modifiers.iter().map(|m| m.to_string()).collect();
+    let str_modifiers: Vec<String> = self.modifiers.iter().map(ToString::to_string).collect();
     let modifiers = str_modifiers.join("+");
     write!(f, "{}+{}", &modifiers, &self.key)
   }

--- a/espanso-detect/src/lib.rs
+++ b/espanso-detect/src/lib.rs
@@ -99,7 +99,7 @@ impl Default for SourceCreationOptions {
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
   info!("using Win32Source");
   Ok(Box::new(win32::Win32Source::new(
     &options.hotkeys,
@@ -109,14 +109,14 @@ pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
 }
 
 #[cfg(target_os = "macos")]
-pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
   info!("using CocoaSource");
   Ok(Box::new(mac::CocoaSource::new(&options.hotkeys)))
 }
 
 #[cfg(target_os = "linux")]
 #[cfg(not(feature = "wayland"))]
-pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
   if options.use_evdev {
     info!("using EVDEVSource");
     Ok(Box::new(evdev::EVDEVSource::new(options)))
@@ -128,7 +128,7 @@ pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
 
 #[cfg(target_os = "linux")]
 #[cfg(feature = "wayland")]
-pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
   info!("using EVDEVSource");
   Ok(Box::new(evdev::EVDEVSource::new(options)))
 }

--- a/espanso-detect/src/lib.rs
+++ b/espanso-detect/src/lib.rs
@@ -122,7 +122,7 @@ pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
     Ok(Box::new(evdev::EVDEVSource::new(options)))
   } else {
     info!("using X11Source");
-    Ok(Box::new(x11::X11Source::new(options.hotkeys)))
+    Ok(Box::new(x11::X11Source::new(&options.hotkeys)))
   }
 }
 

--- a/espanso-detect/src/lib.rs
+++ b/espanso-detect/src/lib.rs
@@ -99,7 +99,7 @@ impl Default for SourceCreationOptions {
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
   info!("using Win32Source");
   Ok(Box::new(win32::Win32Source::new(
     &options.hotkeys,
@@ -109,14 +109,14 @@ pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
 }
 
 #[cfg(target_os = "macos")]
-pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
   info!("using CocoaSource");
   Ok(Box::new(mac::CocoaSource::new(&options.hotkeys)))
 }
 
 #[cfg(target_os = "linux")]
 #[cfg(not(feature = "wayland"))]
-pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
   if options.use_evdev {
     info!("using EVDEVSource");
     Ok(Box::new(evdev::EVDEVSource::new(options)))
@@ -128,7 +128,7 @@ pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
 
 #[cfg(target_os = "linux")]
 #[cfg(feature = "wayland")]
-pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
+pub fn get_source(options: SourceCreationOptions) -> Result<Box<dyn Source>> {
   info!("using EVDEVSource");
   Ok(Box::new(evdev::EVDEVSource::new(options)))
 }

--- a/espanso-detect/src/lib.rs
+++ b/espanso-detect/src/lib.rs
@@ -122,7 +122,7 @@ pub fn get_source(options: &SourceCreationOptions) -> Result<Box<dyn Source>> {
     Ok(Box::new(evdev::EVDEVSource::new(options)))
   } else {
     info!("using X11Source");
-    Ok(Box::new(x11::X11Source::new(&options.hotkeys)))
+    Ok(Box::new(x11::X11Source::new(options.hotkeys)))
   }
 }
 

--- a/espanso-detect/src/win32/mod.rs
+++ b/espanso-detect/src/win32/mod.rs
@@ -168,9 +168,10 @@ impl Source for Win32Source {
   }
 
   fn eventloop(&self, event_callback: SourceCallback) -> Result<()> {
-    if self.handle.is_null() {
-      panic!("Attempt to start Win32Source eventloop without initialization");
-    }
+    assert!(
+      self.handle.is_null(),
+      "Attempt to start Win32Source eventloop without initialization"
+    );
 
     if self.callback.fill(event_callback).is_err() {
       error!("Unable to set Win32Source event callback");

--- a/espanso-detect/src/win32/mod.rs
+++ b/espanso-detect/src/win32/mod.rs
@@ -193,7 +193,7 @@ impl Source for Win32Source {
       let event: Option<InputEvent> = event.into();
       if let Some(callback) = unsafe { (*_self).callback.borrow() } {
         if let Some(event) = event {
-          callback(event)
+          callback(event);
         } else {
           trace!("Unable to convert raw event to input event");
         }

--- a/espanso-detect/src/win32/mod.rs
+++ b/espanso-detect/src/win32/mod.rs
@@ -27,13 +27,20 @@ use widestring::U16CStr;
 use anyhow::Result;
 use thiserror::Error;
 
-use crate::event::{InputEvent, Key, KeyboardEvent, Variant};
-use crate::event::{Key::*, MouseButton, MouseEvent};
-use crate::{event::Status::*, Source, SourceCallback};
-use crate::{
-  event::{HotKeyEvent, Variant::*},
-  hotkey::HotKey,
+use crate::event::{
+  HotKeyEvent, InputEvent,
+  Key::{
+    self, Alt, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Backspace, CapsLock, Control, End, Enter,
+    Escape, Home, Meta, NumLock, Numpad0, Numpad1, Numpad2, Numpad3, Numpad4, Numpad5, Numpad6,
+    Numpad7, Numpad8, Numpad9, Other, PageDown, PageUp, Shift, Space, Tab, F1, F10, F11, F12, F13,
+    F14, F15, F16, F17, F18, F19, F2, F20, F3, F4, F5, F6, F7, F8, F9,
+  },
+  KeyboardEvent, MouseButton, MouseEvent,
+  Status::{Pressed, Released},
+  Variant::{self, Left, Right},
 };
+use crate::hotkey::HotKey;
+use crate::{Source, SourceCallback};
 
 const INPUT_LEFT_VARIANT: i32 = 1;
 const INPUT_RIGHT_VARIANT: i32 = 2;

--- a/espanso-engine/src/dispatch/default.rs
+++ b/espanso-engine/src/dispatch/default.rs
@@ -75,7 +75,7 @@ impl<'a> DefaultDispatcher<'a> {
 
 impl<'a> Dispatcher for DefaultDispatcher<'a> {
   fn dispatch(&self, event: Event) {
-    for executor in self.executors.iter() {
+    for executor in &self.executors {
       if executor.execute(&event) {
         break;
       }

--- a/espanso-engine/src/dispatch/executor/html_inject.rs
+++ b/espanso-engine/src/dispatch/executor/html_inject.rs
@@ -45,7 +45,7 @@ impl<'a> Executor for HtmlInjectExecutor<'a> {
       // Render the text fallback for those applications that don't support HTML clipboard
       let decorator = html2text::render::text_renderer::TrivialDecorator::new();
       let fallback_text =
-        html2text::from_read_with_decorator(inject_event.html.as_bytes(), 1000000, decorator);
+        html2text::from_read_with_decorator(inject_event.html.as_bytes(), 1_000_000, decorator);
 
       if let Err(error) = self
         .injector

--- a/espanso-engine/src/funnel/default.rs
+++ b/espanso-engine/src/funnel/default.rs
@@ -36,7 +36,7 @@ impl<'a> Funnel for DefaultFunnel<'a> {
     let mut select = Select::new();
 
     // First register all the sources to the select operation
-    for source in self.sources.iter() {
+    for source in self.sources {
       source.register(&mut select);
     }
 

--- a/espanso-engine/src/process/default.rs
+++ b/espanso-engine/src/process/default.rs
@@ -132,7 +132,7 @@ impl<'a> DefaultProcessor<'a> {
       };
 
       trace!("--------------- new event -----------------");
-      for middleware in self.middleware.iter() {
+      for middleware in &self.middleware {
         trace!(
           "middleware '{}' received event: {:?}",
           middleware.name(),

--- a/espanso-engine/src/process/middleware/alt_code_synthesizer.rs
+++ b/espanso-engine/src/process/middleware/alt_code_synthesizer.rs
@@ -62,7 +62,7 @@ impl<'a> Middleware for AltCodeSynthesizerMiddleware<'a> {
 
         if keyboard_event.status == Status::Pressed {
           if let Key::Alt = &keyboard_event.key {
-            *code_buffer = Some("".to_owned());
+            *code_buffer = Some(String::new());
           } else if let Some(buffer) = &mut *code_buffer {
             match keyboard_event.key {
               Key::Numpad0 => buffer.push('0'),

--- a/espanso-engine/src/process/middleware/cause.rs
+++ b/espanso-engine/src/process/middleware/cause.rs
@@ -55,9 +55,8 @@ impl Middleware for CauseCompensateMiddleware {
             left_separator: m_event.chosen.left_separator.clone(),
           }),
         );
-      } else {
-        return compensated_event;
       }
+      return compensated_event;
     }
 
     event

--- a/espanso-engine/src/process/middleware/disable.rs
+++ b/espanso-engine/src/process/middleware/disable.rs
@@ -109,7 +109,7 @@ impl Middleware for DisableMiddleware {
         } else {
           EventType::Disabled
         },
-      ))
+      ));
     }
 
     // Block keyboard events when disabled

--- a/espanso-engine/src/process/middleware/markdown.rs
+++ b/espanso-engine/src/process/middleware/markdown.rs
@@ -54,11 +54,9 @@ impl Middleware for MarkdownMiddleware {
             html: html.to_owned(),
           }),
         );
-      } else {
-        error!("unable to convert markdown to HTML, is it malformed?");
-
-        return Event::caused_by(event.source_id, EventType::NOOP);
       }
+      error!("unable to convert markdown to HTML, is it malformed?");
+      return Event::caused_by(event.source_id, EventType::NOOP);
     }
 
     event

--- a/espanso-engine/src/process/middleware/match_exec.rs
+++ b/espanso-engine/src/process/middleware/match_exec.rs
@@ -53,11 +53,11 @@ impl<'a> Middleware for MatchExecRequestMiddleware<'a> {
       };
 
       // Inject the request args into the detected matches
-      matches.iter_mut().for_each(|m| {
+      for m in matches.iter_mut() {
         for (key, value) in &m_event.args {
           m.args.insert(key.to_string(), value.to_string());
         }
-      });
+      }
 
       if matches.is_empty() {
         warn!("received match exec request, but no matches have been found for the given query.");

--- a/espanso-engine/src/process/middleware/match_exec.rs
+++ b/espanso-engine/src/process/middleware/match_exec.rs
@@ -53,7 +53,7 @@ impl<'a> Middleware for MatchExecRequestMiddleware<'a> {
       };
 
       // Inject the request args into the detected matches
-      for m in matches.iter_mut() {
+      for m in &mut matches {
         for (key, value) in &m_event.args {
           m.args.insert(key.to_string(), value.to_string());
         }

--- a/espanso-engine/src/process/middleware/matcher.rs
+++ b/espanso-engine/src/process/middleware/matcher.rs
@@ -103,10 +103,10 @@ impl<'a, State> Middleware for MatcherMiddleware<'a, State> {
   fn next(&self, event: Event, _: &mut dyn FnMut(Event)) -> Event {
     if is_event_of_interest(&event.etype) {
       let mut matcher_states = self.matcher_states.borrow_mut();
-      let prev_states = if !matcher_states.is_empty() {
-        matcher_states.back()
-      } else {
+      let prev_states = if matcher_states.is_empty() {
         None
+      } else {
+        matcher_states.back()
       };
 
       if let EventType::Keyboard(keyboard_event) = &event.etype {

--- a/espanso-engine/src/process/middleware/render.rs
+++ b/espanso-engine/src/process/middleware/render.rs
@@ -71,7 +71,7 @@ impl<'a> Middleware for RenderMiddleware<'a> {
       ) {
         Ok(body) => {
           let body = if let Some(right_separator) = m_event.right_separator {
-            format!("{}{}", body, right_separator)
+            format!("{body}{right_separator}")
           } else {
             body
           };

--- a/espanso-info/src/win32/mod.rs
+++ b/espanso-info/src/win32/mod.rs
@@ -49,10 +49,10 @@ impl WinAppInfoProvider {
     if unsafe { info_get_exec(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) } != 0 {
       let string = unsafe { U16CStr::from_ptr_str(buffer.as_ptr()) };
       let string = string.to_string_lossy();
-      if !string.is_empty() {
-        Some(string)
-      } else {
+      if string.is_empty() {
         None
+      } else {
+        Some(string)
       }
     } else {
       None
@@ -64,10 +64,10 @@ impl WinAppInfoProvider {
     if unsafe { info_get_title(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) } > 0 {
       let string = unsafe { U16CStr::from_ptr_str(buffer.as_ptr()) };
       let string = string.to_string_lossy();
-      if !string.is_empty() {
-        Some(string)
-      } else {
+      if string.is_empty() {
         None
+      } else {
+        Some(string)
       }
     } else {
       None

--- a/espanso-info/src/win32/mod.rs
+++ b/espanso-info/src/win32/mod.rs
@@ -36,15 +36,15 @@ impl WinAppInfoProvider {
 impl AppInfoProvider for WinAppInfoProvider {
   fn get_info(&self) -> AppInfo {
     AppInfo {
-      title: self.get_title(),
+      title: WinAppInfoProvider::get_title(),
       class: None,
-      exec: self.get_exec(),
+      exec: WinAppInfoProvider::get_exec(),
     }
   }
 }
 
 impl WinAppInfoProvider {
-  fn get_exec(&self) -> Option<String> {
+  fn get_exec() -> Option<String> {
     let mut buffer: [u16; 2048] = [0; 2048];
     if unsafe { info_get_exec(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) } != 0 {
       let string = unsafe { U16CStr::from_ptr_str(buffer.as_ptr()) };
@@ -59,7 +59,7 @@ impl WinAppInfoProvider {
     }
   }
 
-  fn get_title(&self) -> Option<String> {
+  fn get_title() -> Option<String> {
     let mut buffer: [u16; 2048] = [0; 2048];
     if unsafe { info_get_title(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) } > 0 {
       let string = unsafe { U16CStr::from_ptr_str(buffer.as_ptr()) };

--- a/espanso-inject/src/keys.rs
+++ b/espanso-inject/src/keys.rs
@@ -226,7 +226,7 @@ impl Display for Key {
       Key::Numpad7 => write!(f, "NUMPAD7"),
       Key::Numpad8 => write!(f, "NUMPAD8"),
       Key::Numpad9 => write!(f, "NUMPAD9"),
-      Key::Raw(code) => write!(f, "RAW({})", code),
+      Key::Raw(code) => write!(f, "RAW({code})"),
     }
   }
 }

--- a/espanso-inject/src/lib.rs
+++ b/espanso-inject/src/lib.rs
@@ -136,20 +136,20 @@ pub trait KeyboardStateProvider {
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_injector(_options: InjectorCreationOptions) -> Result<Box<dyn Injector>> {
+pub fn get_injector(_options: &InjectorCreationOptions) -> Result<Box<dyn Injector>> {
   info!("using Win32Injector");
   Ok(Box::new(win32::Win32Injector::new()))
 }
 
 #[cfg(target_os = "macos")]
-pub fn get_injector(_options: InjectorCreationOptions) -> Result<Box<dyn Injector>> {
+pub fn get_injector(_options: &InjectorCreationOptions) -> Result<Box<dyn Injector>> {
   info!("using MacInjector");
   Ok(Box::new(mac::MacInjector::new()))
 }
 
 #[cfg(target_os = "linux")]
 #[cfg(not(feature = "wayland"))]
-pub fn get_injector(options: InjectorCreationOptions) -> Result<Box<dyn Injector>> {
+pub fn get_injector(options: &InjectorCreationOptions) -> Result<Box<dyn Injector>> {
   if options.use_evdev {
     info!("using EVDEVInjector");
     Ok(Box::new(evdev::EVDEVInjector::new(options)?))

--- a/espanso-inject/src/lib.rs
+++ b/espanso-inject/src/lib.rs
@@ -136,20 +136,20 @@ pub trait KeyboardStateProvider {
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_injector(_options: &InjectorCreationOptions) -> Result<Box<dyn Injector>> {
+pub fn get_injector(_options: InjectorCreationOptions) -> Result<Box<dyn Injector>> {
   info!("using Win32Injector");
   Ok(Box::new(win32::Win32Injector::new()))
 }
 
 #[cfg(target_os = "macos")]
-pub fn get_injector(_options: &InjectorCreationOptions) -> Result<Box<dyn Injector>> {
+pub fn get_injector(_options: InjectorCreationOptions) -> Result<Box<dyn Injector>> {
   info!("using MacInjector");
   Ok(Box::new(mac::MacInjector::new()))
 }
 
 #[cfg(target_os = "linux")]
 #[cfg(not(feature = "wayland"))]
-pub fn get_injector(options: &InjectorCreationOptions) -> Result<Box<dyn Injector>> {
+pub fn get_injector(options: InjectorCreationOptions) -> Result<Box<dyn Injector>> {
   if options.use_evdev {
     info!("using EVDEVInjector");
     Ok(Box::new(evdev::EVDEVInjector::new(options)?))

--- a/espanso-inject/src/win32/mod.rs
+++ b/espanso-inject/src/win32/mod.rs
@@ -50,7 +50,7 @@ impl Win32Injector {
     for key in keys.iter() {
       let vk = convert_key_to_vkey(key);
       if let Some(vk) = vk {
-        virtual_keys.push(vk)
+        virtual_keys.push(vk);
       } else {
         return Err(Win32InjectorError::MappingFailure(key.clone()).into());
       }

--- a/espanso-inject/src/win32/mod.rs
+++ b/espanso-inject/src/win32/mod.rs
@@ -47,7 +47,7 @@ impl Win32Injector {
 
   pub fn convert_to_vk_array(keys: &[keys::Key]) -> Result<Vec<i32>> {
     let mut virtual_keys: Vec<i32> = Vec::new();
-    for key in keys.iter() {
+    for key in keys {
       let vk = convert_key_to_vkey(key);
       if let Some(vk) = vk {
         virtual_keys.push(vk);

--- a/espanso-ipc/src/util.rs
+++ b/espanso-ipc/src/util.rs
@@ -32,10 +32,8 @@ pub fn read_line<R: std::io::Read>(stream: R) -> Result<Option<String>> {
     if byte == 10 {
       // Newline
       break;
-    } else {
-      buffer.push(byte);
     }
-
+    buffer.push(byte);
     is_eof = false;
   }
 

--- a/espanso-ipc/src/windows.rs
+++ b/espanso-ipc/src/windows.rs
@@ -34,7 +34,7 @@ pub struct WinIPCServer {
 
 impl WinIPCServer {
   pub fn new(id: &str) -> Result<Self> {
-    let pipe_name = format!("\\\\.\\pipe\\{}", id);
+    let pipe_name = format!("\\\\.\\pipe\\{id}");
 
     let options = PipeOptions::new(&pipe_name);
     let server = Some(options.single()?);
@@ -105,7 +105,7 @@ pub struct WinIPCClient {
 
 impl WinIPCClient {
   pub fn new(id: &str) -> Result<Self> {
-    let pipe_name = format!("\\\\.\\pipe\\{}", id);
+    let pipe_name = format!("\\\\.\\pipe\\{id}");
 
     let stream = PipeClient::connect_ms(pipe_name, DEFAULT_CLIENT_TIMEOUT)?;
     Ok(Self { stream })

--- a/espanso-match/src/lib.rs
+++ b/espanso-match/src/lib.rs
@@ -39,7 +39,7 @@ impl<Id: Default> Default for MatchResult<Id> {
   fn default() -> Self {
     Self {
       id: Id::default(),
-      trigger: "".to_string(),
+      trigger: String::new(),
       left_separator: None,
       right_separator: None,
       vars: HashMap::new(),

--- a/espanso-match/src/regex/mod.rs
+++ b/espanso-match/src/regex/mod.rs
@@ -80,7 +80,7 @@ where
     let mut buffer = if let Some(prev_state) = prev_state {
       prev_state.buffer.clone()
     } else {
-      "".to_string()
+      String::new()
     };
 
     if let Event::Key {

--- a/espanso-match/src/regex/mod.rs
+++ b/espanso-match/src/regex/mod.rs
@@ -142,7 +142,7 @@ where
 }
 
 impl<Id: Clone> RegexMatcher<Id> {
-  pub fn new(matches: &[RegexMatch<Id>], opt: &RegexMatcherOptions) -> Self {
+  pub fn new(matches: &[RegexMatch<Id>], opt: RegexMatcherOptions) -> Self {
     let mut ids = Vec::new();
     let mut regexes = Vec::new();
     let mut good_regexes = Vec::new();
@@ -198,7 +198,7 @@ mod tests {
         RegexMatch::new(1, "hello"),
         RegexMatch::new(2, "num\\d{1,3}s"),
       ],
-      &RegexMatcherOptions::default(),
+      RegexMatcherOptions::default(),
     );
     assert_eq!(get_matches_after_str("hi", &matcher), vec![]);
     assert_eq!(
@@ -227,7 +227,7 @@ mod tests {
         RegexMatch::new(1, "hello\\((?P<name>.*?)\\)"),
         RegexMatch::new(2, "multi\\((?P<name1>.*?),(?P<name2>.*?)\\)"),
       ],
-      &RegexMatcherOptions::default(),
+      RegexMatcherOptions::default(),
     );
     assert_eq!(get_matches_after_str("hi", &matcher), vec![]);
     assert_eq!(
@@ -252,7 +252,7 @@ mod tests {
         RegexMatch::new(1, "hello\\((?P<name>.*?)\\)"),
         RegexMatch::new(2, "multi\\((?P<name1>.*?),(?P<name2>.*?)\\)"),
       ],
-      &RegexMatcherOptions {
+      RegexMatcherOptions {
         max_buffer_size: 15,
       },
     );

--- a/espanso-match/src/regex/mod.rs
+++ b/espanso-match/src/regex/mod.rs
@@ -142,7 +142,7 @@ where
 }
 
 impl<Id: Clone> RegexMatcher<Id> {
-  pub fn new(matches: &[RegexMatch<Id>], opt: RegexMatcherOptions) -> Self {
+  pub fn new(matches: &[RegexMatch<Id>], opt: &RegexMatcherOptions) -> Self {
     let mut ids = Vec::new();
     let mut regexes = Vec::new();
     let mut good_regexes = Vec::new();
@@ -198,7 +198,7 @@ mod tests {
         RegexMatch::new(1, "hello"),
         RegexMatch::new(2, "num\\d{1,3}s"),
       ],
-      RegexMatcherOptions::default(),
+      &RegexMatcherOptions::default(),
     );
     assert_eq!(get_matches_after_str("hi", &matcher), vec![]);
     assert_eq!(
@@ -227,7 +227,7 @@ mod tests {
         RegexMatch::new(1, "hello\\((?P<name>.*?)\\)"),
         RegexMatch::new(2, "multi\\((?P<name1>.*?),(?P<name2>.*?)\\)"),
       ],
-      RegexMatcherOptions::default(),
+      &RegexMatcherOptions::default(),
     );
     assert_eq!(get_matches_after_str("hi", &matcher), vec![]);
     assert_eq!(
@@ -252,7 +252,7 @@ mod tests {
         RegexMatch::new(1, "hello\\((?P<name>.*?)\\)"),
         RegexMatch::new(2, "multi\\((?P<name1>.*?),(?P<name2>.*?)\\)"),
       ],
-      RegexMatcherOptions {
+      &RegexMatcherOptions {
         max_buffer_size: 15,
       },
     );

--- a/espanso-match/src/rolling/matcher.rs
+++ b/espanso-match/src/rolling/matcher.rs
@@ -153,13 +153,13 @@ impl<Id: Clone> RollingMatcher<Id> {
 
     if let Event::Key { key, chars } = event {
       // Key matching
-      if let Some((_, node_ref)) = node.keys.iter().find(|(_key, _)| _key == key) {
+      if let Some((_, node_ref)) = node.keys.iter().find(|(k, _)| k == key) {
         refs.push((node_ref, false));
       }
 
       if let Some(char) = chars {
         // Char matching
-        if let Some((_, node_ref)) = node.chars.iter().find(|(_char, _)| _char == char) {
+        if let Some((_, node_ref)) = node.chars.iter().find(|(c, _)| c == char) {
           refs.push((node_ref, false));
         }
 
@@ -168,7 +168,7 @@ impl<Id: Clone> RollingMatcher<Id> {
         if let Some((_, node_ref)) = node
           .chars_insensitive
           .iter()
-          .find(|(_char, _)| *_char == insensitive_char)
+          .find(|(c, _)| *c == insensitive_char)
         {
           refs.push((node_ref, false));
         }

--- a/espanso-match/src/rolling/matcher.rs
+++ b/espanso-match/src/rolling/matcher.rs
@@ -177,7 +177,7 @@ impl<Id: Clone> RollingMatcher<Id> {
 
     if self.is_word_separator(event) {
       if let Some(node_ref) = node.word_separators.as_ref() {
-        refs.push((node_ref, true))
+        refs.push((node_ref, true));
       }
     }
 

--- a/espanso-match/src/rolling/matcher.rs
+++ b/espanso-match/src/rolling/matcher.rs
@@ -76,7 +76,7 @@ where
 
     // First compute the old refs
     if let Some(prev_state) = prev_state {
-      for node_path in prev_state.paths.iter() {
+      for node_path in &prev_state.paths {
         next_refs.extend(
           self
             .find_refs(node_path.node, &event, true)

--- a/espanso-match/src/rolling/mod.rs
+++ b/espanso-match/src/rolling/mod.rs
@@ -51,9 +51,9 @@ impl<Id> RollingMatch<Id> {
 
     for c in string.chars() {
       if opt.case_insensitive {
-        items.push(RollingItem::CharInsensitive(c.to_string()))
+        items.push(RollingItem::CharInsensitive(c.to_string()));
       } else {
-        items.push(RollingItem::Char(c.to_string()))
+        items.push(RollingItem::Char(c.to_string()));
       }
     }
 

--- a/espanso-match/src/rolling/mod.rs
+++ b/espanso-match/src/rolling/mod.rs
@@ -96,7 +96,7 @@ mod tests {
           RollingItem::Char("t".to_string()),
         ]
       }
-    )
+    );
   }
 
   #[test]
@@ -120,7 +120,7 @@ mod tests {
           RollingItem::Char("t".to_string()),
         ]
       }
-    )
+    );
   }
 
   #[test]
@@ -144,7 +144,7 @@ mod tests {
           RollingItem::WordSeparator,
         ]
       }
-    )
+    );
   }
 
   #[test]
@@ -167,6 +167,6 @@ mod tests {
           RollingItem::CharInsensitive("t".to_string()),
         ]
       }
-    )
+    );
   }
 }

--- a/espanso-match/src/rolling/tree.rs
+++ b/espanso-match/src/rolling/tree.rs
@@ -78,7 +78,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
         node.word_separators = Some(MatcherTreeRef::Matches(new_matches));
       }
       RollingItem::Key(key) => {
-        if let Some(entry) = node.keys.iter_mut().find(|(_key, _)| _key == key) {
+        if let Some(entry) = node.keys.iter_mut().find(|(k, _)| k == key) {
           if let MatcherTreeRef::Matches(matches) = &mut entry.1 {
             matches.push(id);
           } else {
@@ -91,7 +91,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
         }
       }
       RollingItem::Char(c) => {
-        if let Some(entry) = node.chars.iter_mut().find(|(_c, _)| _c == c) {
+        if let Some(entry) = node.chars.iter_mut().find(|(char, _)| char == c) {
           if let MatcherTreeRef::Matches(matches) = &mut entry.1 {
             matches.push(id);
           } else {
@@ -108,7 +108,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
         if let Some(entry) = node
           .chars_insensitive
           .iter_mut()
-          .find(|(_c, _)| _c == &uni_char)
+          .find(|(c, _)| c == &uni_char)
         {
           if let MatcherTreeRef::Matches(matches) = &mut entry.1 {
             matches.push(id);
@@ -136,7 +136,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
         _ => {}
       },
       RollingItem::Key(key) => {
-        if let Some(entry) = node.keys.iter_mut().find(|(_key, _)| _key == key) {
+        if let Some(entry) = node.keys.iter_mut().find(|(k, _)| k == key) {
           if let MatcherTreeRef::Node(next_node) = &mut entry.1 {
             insert_items_recursively(id, next_node, &items[1..]);
           }

--- a/espanso-match/src/rolling/tree.rs
+++ b/espanso-match/src/rolling/tree.rs
@@ -75,14 +75,14 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
           new_matches.extend(matches);
         }
         new_matches.push(id);
-        node.word_separators = Some(MatcherTreeRef::Matches(new_matches))
+        node.word_separators = Some(MatcherTreeRef::Matches(new_matches));
       }
       RollingItem::Key(key) => {
         if let Some(entry) = node.keys.iter_mut().find(|(_key, _)| _key == key) {
           if let MatcherTreeRef::Matches(matches) = &mut entry.1 {
-            matches.push(id)
+            matches.push(id);
           } else {
-            entry.1 = MatcherTreeRef::Matches(vec![id])
+            entry.1 = MatcherTreeRef::Matches(vec![id]);
           };
         } else {
           node
@@ -93,9 +93,9 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
       RollingItem::Char(c) => {
         if let Some(entry) = node.chars.iter_mut().find(|(_c, _)| _c == c) {
           if let MatcherTreeRef::Matches(matches) = &mut entry.1 {
-            matches.push(id)
+            matches.push(id);
           } else {
-            entry.1 = MatcherTreeRef::Matches(vec![id])
+            entry.1 = MatcherTreeRef::Matches(vec![id]);
           };
         } else {
           node
@@ -111,9 +111,9 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
           .find(|(_c, _)| _c == &uni_char)
         {
           if let MatcherTreeRef::Matches(matches) = &mut entry.1 {
-            matches.push(id)
+            matches.push(id);
           } else {
-            entry.1 = MatcherTreeRef::Matches(vec![id])
+            entry.1 = MatcherTreeRef::Matches(vec![id]);
           };
         } else {
           node
@@ -126,7 +126,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
     match item {
       RollingItem::WordSeparator => match node.word_separators.as_mut() {
         Some(MatcherTreeRef::Node(next_node)) => {
-          insert_items_recursively(id, next_node.as_mut(), &items[1..])
+          insert_items_recursively(id, next_node.as_mut(), &items[1..]);
         }
         None => {
           let mut next_node = Box::<MatcherTreeNode<Id>>::default();
@@ -138,7 +138,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
       RollingItem::Key(key) => {
         if let Some(entry) = node.keys.iter_mut().find(|(_key, _)| _key == key) {
           if let MatcherTreeRef::Node(next_node) = &mut entry.1 {
-            insert_items_recursively(id, next_node, &items[1..])
+            insert_items_recursively(id, next_node, &items[1..]);
           }
         } else {
           let mut next_node = Box::<MatcherTreeNode<Id>>::default();
@@ -151,7 +151,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
       RollingItem::Char(c) => {
         if let Some(entry) = node.chars.iter_mut().find(|(_c, _)| _c == c) {
           if let MatcherTreeRef::Node(next_node) = &mut entry.1 {
-            insert_items_recursively(id, next_node, &items[1..])
+            insert_items_recursively(id, next_node, &items[1..]);
           }
         } else {
           let mut next_node = Box::<MatcherTreeNode<Id>>::default();
@@ -169,7 +169,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
           .find(|(_c, _)| _c == &uni_char)
         {
           if let MatcherTreeRef::Node(next_node) = &mut entry.1 {
-            insert_items_recursively(id, next_node, &items[1..])
+            insert_items_recursively(id, next_node, &items[1..]);
           }
         } else {
           let mut next_node = Box::<MatcherTreeNode<Id>>::default();

--- a/espanso-match/src/rolling/tree.rs
+++ b/espanso-match/src/rolling/tree.rs
@@ -149,7 +149,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
         }
       }
       RollingItem::Char(c) => {
-        if let Some(entry) = node.chars.iter_mut().find(|(_c, _)| _c == c) {
+        if let Some(entry) = node.chars.iter_mut().find(|(char, _)| char == c) {
           if let MatcherTreeRef::Node(next_node) = &mut entry.1 {
             insert_items_recursively(id, next_node, &items[1..]);
           }
@@ -166,7 +166,7 @@ fn insert_items_recursively<Id>(id: Id, node: &mut MatcherTreeNode<Id>, items: &
         if let Some(entry) = node
           .chars_insensitive
           .iter_mut()
-          .find(|(_c, _)| _c == &uni_char)
+          .find(|(c, _)| c == &uni_char)
         {
           if let MatcherTreeRef::Node(next_node) = &mut entry.1 {
             insert_items_recursively(id, next_node, &items[1..]);

--- a/espanso-match/src/rolling/tree.rs
+++ b/espanso-match/src/rolling/tree.rs
@@ -227,7 +227,7 @@ mod tests {
         ],
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -264,7 +264,7 @@ mod tests {
         ),],
         ..Default::default()
       }
-    )
+    );
   }
 
   #[test]
@@ -351,6 +351,6 @@ mod tests {
         ),],
         ..Default::default()
       }
-    )
+    );
   }
 }

--- a/espanso-match/src/rolling/util.rs
+++ b/espanso-match/src/rolling/util.rs
@@ -166,7 +166,7 @@ mod tests {
           false
         ),
       ]),
-      ("".to_string(), None, None)
+      (String::new(), None, None)
     );
   }
 

--- a/espanso-match/src/util.rs
+++ b/espanso-match/src/util.rs
@@ -32,7 +32,7 @@ pub(crate) mod tests {
     let mut matches = Vec::new();
 
     for c in string.chars() {
-      let (state, _matches) = matcher.process(
+      let (state, vec_matches) = matcher.process(
         prev_state.as_ref(),
         Event::Key {
           key: Key::Other,
@@ -41,7 +41,7 @@ pub(crate) mod tests {
       );
 
       prev_state = Some(state);
-      matches = _matches;
+      matches = vec_matches;
     }
 
     matches

--- a/espanso-migrate/src/convert.rs
+++ b/espanso-migrate/src/convert.rs
@@ -54,10 +54,7 @@ pub fn convert(input_files: HashMap<String, Hash>) -> HashMap<String, ConvertedF
       let should_underscore = !input_path.starts_with("default") && yaml_parent != Some("default");
       let match_output_path = calculate_output_match_path(&input_path, should_underscore);
       if match_output_path.is_none() {
-        eprintln!(
-          "unable to determine output path for {}, skipping...",
-          input_path
-        );
+        eprintln!("unable to determine output path for {input_path}, skipping...");
         continue;
       }
       let match_output_path = match_output_path.unwrap();
@@ -82,7 +79,7 @@ pub fn convert(input_files: HashMap<String, Hash>) -> HashMap<String, ConvertedF
         if let Yaml::Array(out_global_vars) = output_global_vars {
           out_global_vars.extend(patched_global_vars);
         } else {
-          eprintln!("unable to transform global_vars for file: {}", input_path);
+          eprintln!("unable to transform global_vars for file: {input_path}");
         }
       }
 
@@ -97,7 +94,7 @@ pub fn convert(input_files: HashMap<String, Hash>) -> HashMap<String, ConvertedF
         if let Yaml::Array(out_matches) = output_matches {
           out_matches.extend(patched_matches);
         } else {
-          eprintln!("unable to transform matches for file: {}", input_path);
+          eprintln!("unable to transform matches for file: {input_path}");
         }
       }
 
@@ -220,7 +217,7 @@ pub fn convert(input_files: HashMap<String, Hash>) -> HashMap<String, ConvertedF
           "extra_includes"
         };
 
-        let includes = vec![Yaml::String(format!("../{}", match_file_path))];
+        let includes = vec![Yaml::String(format!("../{match_file_path}"))];
 
         output_yaml.insert(Yaml::String(key_name.to_string()), Yaml::Array(includes));
       }
@@ -261,7 +258,7 @@ fn calculate_output_match_path(path: &str, is_underscored: bool) -> Option<Strin
   let file_name = path_buf.file_name()?.to_string_lossy().to_string();
 
   let path = if is_underscored {
-    path.replace(&file_name, &format!("_{}", file_name))
+    path.replace(&file_name, &format!("_{file_name}"))
   } else {
     path.to_string()
   };
@@ -273,7 +270,7 @@ fn calculate_output_match_path(path: &str, is_underscored: bool) -> Option<Strin
   } else if path == "default.yml" {
     "match/base.yml".to_string()
   } else {
-    format!("match/{}", path)
+    format!("match/{path}")
   })
 }
 
@@ -284,7 +281,7 @@ fn calculate_output_config_path(path: &str) -> String {
   } else if path.starts_with("packages/") {
     format!("config/packages/{}", path.trim_start_matches("packages/"))
   } else {
-    format!("config/{}", path)
+    format!("config/{path}")
   }
 }
 
@@ -329,7 +326,7 @@ fn map_field_if_present(
     if let Some(transformed) = transformed {
       output_yaml.insert(Yaml::String(output_field_name.to_string()), transformed);
     } else {
-      eprintln!("could not convert value for field: {}", input_field_name);
+      eprintln!("could not convert value for field: {input_field_name}");
     }
   }
 }
@@ -383,7 +380,7 @@ fn replace_legacy_form_syntax_with_new_one(layout: &str) -> String {
   LEGACY_FIELD_REGEX
     .replace_all(layout, |caps: &Captures| {
       let field_name = caps.name("name").unwrap().as_str();
-      format!("[[{}]]", field_name)
+      format!("[[{field_name}]]")
     })
     .to_string()
 }

--- a/espanso-migrate/src/convert.rs
+++ b/espanso-migrate/src/convert.rs
@@ -333,7 +333,7 @@ fn map_field_if_present(
 
 // This is needed to convert the old form's {{control}} syntax to the new [[control]] one.
 fn apply_form_syntax_patch(matches: &mut [Yaml]) {
-  matches.iter_mut().for_each(|m| {
+  for m in matches.iter_mut() {
     if let Yaml::Hash(fields) = m {
       if let Some(Yaml::String(form_option)) = fields.get_mut(&Yaml::String("form".to_string())) {
         let converted = replace_legacy_form_syntax_with_new_one(form_option);
@@ -349,7 +349,7 @@ fn apply_form_syntax_patch(matches: &mut [Yaml]) {
           .for_each(apply_form_syntax_patch_to_variable);
       }
     }
-  });
+  }
 }
 
 fn apply_form_syntax_patch_to_variable(variable: &mut Yaml) {

--- a/espanso-migrate/src/convert.rs
+++ b/espanso-migrate/src/convert.rs
@@ -26,10 +26,10 @@ pub struct ConvertedFile {
   pub content: Hash,
 }
 
-pub fn convert(input_files: &HashMap<String, Hash>) -> HashMap<String, ConvertedFile> {
+pub fn convert(input_files: HashMap<String, Hash>) -> HashMap<String, ConvertedFile> {
   let mut output_files = HashMap::new();
 
-  let sorted_input_files = sort_input_files(input_files);
+  let sorted_input_files = sort_input_files(&input_files);
 
   for input_path in sorted_input_files {
     let yaml = input_files

--- a/espanso-migrate/src/convert.rs
+++ b/espanso-migrate/src/convert.rs
@@ -26,10 +26,10 @@ pub struct ConvertedFile {
   pub content: Hash,
 }
 
-pub fn convert(input_files: HashMap<String, Hash>) -> HashMap<String, ConvertedFile> {
+pub fn convert(input_files: &HashMap<String, Hash>) -> HashMap<String, ConvertedFile> {
   let mut output_files = HashMap::new();
 
-  let sorted_input_files = sort_input_files(&input_files);
+  let sorted_input_files = sort_input_files(input_files);
 
   for input_path in sorted_input_files {
     let yaml = input_files

--- a/espanso-migrate/src/convert.rs
+++ b/espanso-migrate/src/convert.rs
@@ -300,7 +300,7 @@ fn yaml_get_string<'a>(yaml: &'a Hash, name: &str) -> Option<&'a str> {
 fn yaml_get_bool(yaml: &Hash, name: &str) -> Option<bool> {
   yaml
     .get(&Yaml::String(name.to_string()))
-    .and_then(|v| v.as_bool())
+    .and_then(Yaml::as_bool)
 }
 
 fn copy_field_if_present(

--- a/espanso-migrate/src/convert.rs
+++ b/espanso-migrate/src/convert.rs
@@ -349,10 +349,10 @@ fn apply_form_syntax_patch(matches: &mut [Yaml]) {
       if let Some(Yaml::Array(vars)) = fields.get_mut(&Yaml::String("vars".to_string())) {
         vars
           .iter_mut()
-          .for_each(apply_form_syntax_patch_to_variable)
+          .for_each(apply_form_syntax_patch_to_variable);
       }
     }
-  })
+  });
 }
 
 fn apply_form_syntax_patch_to_variable(variable: &mut Yaml) {

--- a/espanso-migrate/src/lib.rs
+++ b/espanso-migrate/src/lib.rs
@@ -92,7 +92,7 @@ pub fn migrate(config_dir: &Path, packages_dir: &Path, output_dir: &Path) -> Res
 
   // Convert the configurations
   let legacy_files = load::load(working_dir.path())?;
-  let converted_files = convert::convert(legacy_files);
+  let converted_files = convert::convert(&legacy_files);
   let rendered_files = render::render(converted_files)?;
 
   for (file, content) in rendered_files {

--- a/espanso-migrate/src/lib.rs
+++ b/espanso-migrate/src/lib.rs
@@ -92,7 +92,7 @@ pub fn migrate(config_dir: &Path, packages_dir: &Path, output_dir: &Path) -> Res
 
   // Convert the configurations
   let legacy_files = load::load(working_dir.path())?;
-  let converted_files = convert::convert(&legacy_files);
+  let converted_files = convert::convert(legacy_files);
   let rendered_files = render::render(converted_files)?;
 
   for (file, content) in rendered_files {

--- a/espanso-migrate/src/load.rs
+++ b/espanso-migrate/src/load.rs
@@ -112,7 +112,7 @@ pub fn load(config_dir: &Path) -> Result<HashMap<String, Hash>> {
         }
       }
       Err(err) => {
-        eprintln!("experienced error while reading entry: {}", err)
+        eprintln!("experienced error while reading entry: {}", err);
       }
     }
   }

--- a/espanso-migrate/src/load.rs
+++ b/espanso-migrate/src/load.rs
@@ -112,7 +112,7 @@ pub fn load(config_dir: &Path) -> Result<HashMap<String, Hash>> {
         }
       }
       Err(err) => {
-        eprintln!("experienced error while reading entry: {}", err);
+        eprintln!("experienced error while reading entry: {err}");
       }
     }
   }

--- a/espanso-migrate/src/load.rs
+++ b/espanso-migrate/src/load.rs
@@ -66,7 +66,12 @@ pub fn load(config_dir: &Path) -> Result<HashMap<String, Hash>> {
                 } else {
                   match YamlLoader::load_from_str(&content) {
                     Ok(mut yaml) => {
-                      if !yaml.is_empty() {
+                      if yaml.is_empty() {
+                        eprintln!(
+                          "error, found empty document while reading entry: {}",
+                          entry.path().display()
+                        );
+                      } else {
                         let yaml = yaml.remove(0);
                         if let Yaml::Hash(hash) = yaml {
                           input_files.insert(corrected_path, hash);
@@ -76,11 +81,6 @@ pub fn load(config_dir: &Path) -> Result<HashMap<String, Hash>> {
                             entry.path().display()
                           );
                         }
-                      } else {
-                        eprintln!(
-                          "error, found empty document while reading entry: {}",
-                          entry.path().display()
-                        );
                       }
                     }
                     Err(err) => {

--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -35,9 +35,7 @@ fn build_native() {
   let project_dir =
     PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR"));
   let wx_archive = project_dir.join("vendor").join(WX_WIDGETS_ARCHIVE_NAME);
-  if !wx_archive.is_file() {
-    panic!("could not find wxWidgets archive!");
-  }
+  assert!(wx_archive.is_file(), "could not find wxWidgets archive!")
 
   let out_dir = if let Ok(out_path) = std::env::var(WX_WIDGETS_BUILD_OUT_DIR_ENV_NAME) {
     println!(

--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -35,7 +35,7 @@ fn build_native() {
   let project_dir =
     PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("missing CARGO_MANIFEST_DIR"));
   let wx_archive = project_dir.join("vendor").join(WX_WIDGETS_ARCHIVE_NAME);
-  assert!(wx_archive.is_file(), "could not find wxWidgets archive!")
+  assert!(wx_archive.is_file(), "could not find wxWidgets archive!");
 
   let out_dir = if let Ok(out_path) = std::env::var(WX_WIDGETS_BUILD_OUT_DIR_ENV_NAME) {
     println!(

--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -38,10 +38,7 @@ fn build_native() {
   assert!(wx_archive.is_file(), "could not find wxWidgets archive!");
 
   let out_dir = if let Ok(out_path) = std::env::var(WX_WIDGETS_BUILD_OUT_DIR_ENV_NAME) {
-    println!(
-      "detected wxWidgets build output directory override: {}",
-      out_path
-    );
+    println!("detected wxWidgets build output directory override: {out_path}");
     let path = PathBuf::from(out_path);
     std::fs::create_dir_all(&path).expect("unable to create wxWidgets out dir");
     path

--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -68,49 +68,22 @@ pub enum FieldTypeConfig {
   List(ListFieldConfig),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct TextFieldConfig {
   pub default: String,
   pub multiline: bool,
 }
 
-impl Default for TextFieldConfig {
-  fn default() -> Self {
-    Self {
-      default: String::new(),
-      multiline: false,
-    }
-  }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ChoiceFieldConfig {
   pub values: Vec<String>,
   pub default: String,
 }
 
-impl Default for ChoiceFieldConfig {
-  fn default() -> Self {
-    Self {
-      values: Vec::new(),
-      default: String::new(),
-    }
-  }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ListFieldConfig {
   pub values: Vec<String>,
   pub default: String,
-}
-
-impl Default for ListFieldConfig {
-  fn default() -> Self {
-    Self {
-      values: Vec::new(),
-      default: String::new(),
-    }
-  }
 }
 
 impl<'de> serde::Deserialize<'de> for FieldConfig {

--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -77,7 +77,7 @@ pub struct TextFieldConfig {
 impl Default for TextFieldConfig {
   fn default() -> Self {
     Self {
-      default: "".to_owned(),
+      default: String::new(),
       multiline: false,
     }
   }
@@ -93,7 +93,7 @@ impl Default for ChoiceFieldConfig {
   fn default() -> Self {
     Self {
       values: Vec::new(),
-      default: "".to_owned(),
+      default: String::new(),
     }
   }
 }
@@ -108,7 +108,7 @@ impl Default for ListFieldConfig {
   fn default() -> Self {
     Self {
       values: Vec::new(),
-      default: "".to_owned(),
+      default: String::new(),
     }
   }
 }

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -69,7 +69,7 @@ fn build_form(form: FormConfig, structure: Vec<Vec<Token>>) -> Form {
   let field_map = form.fields;
   let mut fields = Vec::new();
 
-  for row in structure.iter() {
+  for row in &structure {
     let current_field = if row.len() == 1 {
       // Single field
       create_field(&row[0], &field_map)

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -19,7 +19,9 @@
 
 use super::config::{FieldConfig, FieldTypeConfig, FormConfig};
 use super::parser::layout::Token;
-use crate::sys::form::types::*;
+use crate::sys::form::types::{
+  ChoiceMetadata, ChoiceType, Field, FieldType, Form, LabelMetadata, RowMetadata, TextMetadata,
+};
 use std::collections::HashMap;
 
 pub fn generate(config: FormConfig) -> Form {

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -88,7 +88,7 @@ fn build_form(form: FormConfig, structure: Vec<Vec<Token>>) -> Form {
       }
     };
 
-    fields.push(current_field)
+    fields.push(current_field);
   }
 
   Form {

--- a/espanso-modulo/src/form/parser/layout.rs
+++ b/espanso-modulo/src/form/parser/layout.rs
@@ -51,7 +51,7 @@ pub fn parse_layout(layout: &str) -> Vec<Vec<Token>> {
       match state {
         SplitState::Unmatched(text) => {
           if !text.is_empty() {
-            row.push(Token::Text(text.to_owned()))
+            row.push(Token::Text(text.to_owned()));
           }
         }
         SplitState::Captured(caps) => {

--- a/espanso-modulo/src/search/algorithm.rs
+++ b/espanso-modulo/src/search/algorithm.rs
@@ -78,7 +78,7 @@ fn case_insensitive_keyword(query: &str, items: &[SearchItem]) -> Vec<usize> {
     .iter()
     .enumerate()
     .filter(|(_, item)| {
-      for keyword in keywords.iter() {
+      for keyword in &keywords {
         if !item.label.to_lowercase().contains(keyword)
           && !item
             .trigger

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -89,6 +89,8 @@ pub mod types {
 
 #[allow(dead_code)]
 mod interop {
+  use crate::sys;
+
   use super::super::interop::*;
   use super::types;
   use std::ffi::{c_void, CString};
@@ -113,9 +115,12 @@ mod interop {
   impl From<types::Form> for OwnedForm {
     fn from(form: types::Form) -> Self {
       let title = CString::new(form.title).expect("unable to convert form title to CString");
-      let fields: Vec<OwnedField> = form.fields.into_iter().map(|field| field.into()).collect();
+      let fields: Vec<OwnedField> = form.fields.into_iter().map(Into::into).collect();
 
-      let _metadata: Vec<FieldMetadata> = fields.iter().map(|field| field.metadata()).collect();
+      let _metadata: Vec<FieldMetadata> = fields
+        .iter()
+        .map(sys::form::interop::OwnedField::metadata)
+        .collect();
 
       let icon_path = if let Some(icon_path) = form.icon.as_ref() {
         icon_path.clone()
@@ -323,13 +328,12 @@ mod interop {
 
   impl From<types::RowMetadata> for OwnedRowMetadata {
     fn from(row_metadata: types::RowMetadata) -> Self {
-      let fields: Vec<OwnedField> = row_metadata
-        .fields
-        .into_iter()
-        .map(|field| field.into())
-        .collect();
+      let fields: Vec<OwnedField> = row_metadata.fields.into_iter().map(Into::into).collect();
 
-      let _metadata: Vec<FieldMetadata> = fields.iter().map(|field| field.metadata()).collect();
+      let _metadata: Vec<FieldMetadata> = fields
+        .iter()
+        .map(sys::form::interop::OwnedField::metadata)
+        .collect();
 
       let _interop = Box::new(RowMetadata {
         fields: _metadata.as_ptr(),

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -362,7 +362,7 @@ pub fn show(form: types::Form) -> HashMap<String, String> {
     let values: &[ValuePair] = unsafe { std::slice::from_raw_parts(values, size as usize) };
     let map = map as *mut HashMap<String, String>;
     let map = unsafe { &mut (*map) };
-    for pair in values.iter() {
+    for pair in values {
       unsafe {
         let id = CStr::from_ptr(pair.id);
         let value = CStr::from_ptr(pair.value);

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -102,13 +102,13 @@ mod interop {
     icon_path: CString,
     fields: Vec<OwnedField>,
 
-    _metadata: Vec<FieldMetadata>,
-    _interop: Box<FormMetadata>,
+    metadata: Vec<FieldMetadata>,
+    interop: Box<FormMetadata>,
   }
 
   impl Interoperable for OwnedForm {
     fn as_ptr(&self) -> *const c_void {
-      &(*self._interop) as *const FormMetadata as *const c_void
+      &(*self.interop) as *const FormMetadata as *const c_void
     }
   }
 
@@ -117,7 +117,7 @@ mod interop {
       let title = CString::new(form.title).expect("unable to convert form title to CString");
       let fields: Vec<OwnedField> = form.fields.into_iter().map(Into::into).collect();
 
-      let _metadata: Vec<FieldMetadata> = fields
+      let metadata: Vec<FieldMetadata> = fields
         .iter()
         .map(sys::form::interop::OwnedField::metadata)
         .collect();
@@ -136,10 +136,10 @@ mod interop {
         std::ptr::null()
       };
 
-      let _interop = Box::new(FormMetadata {
+      let interop = Box::new(FormMetadata {
         windowTitle: title.as_ptr(),
         iconPath: icon_path_ptr,
-        fields: _metadata.as_ptr(),
+        fields: metadata.as_ptr(),
         fieldSize: fields.len() as c_int,
       });
 
@@ -147,8 +147,8 @@ mod interop {
         title,
         icon_path,
         fields,
-        _metadata,
-        _interop,
+        metadata,
+        interop,
       }
     }
   }
@@ -220,12 +220,12 @@ mod interop {
 
   struct OwnedLabelMetadata {
     text: CString,
-    _interop: Box<LabelMetadata>,
+    interop: Box<LabelMetadata>,
   }
 
   impl Interoperable for OwnedLabelMetadata {
     fn as_ptr(&self) -> *const c_void {
-      &(*self._interop) as *const LabelMetadata as *const c_void
+      &(*self.interop) as *const LabelMetadata as *const c_void
     }
   }
 
@@ -233,21 +233,21 @@ mod interop {
     fn from(label_metadata: types::LabelMetadata) -> Self {
       let text =
         CString::new(label_metadata.text).expect("unable to convert label text to CString");
-      let _interop = Box::new(LabelMetadata {
+      let interop = Box::new(LabelMetadata {
         text: text.as_ptr(),
       });
-      Self { text, _interop }
+      Self { text, interop }
     }
   }
 
   struct OwnedTextMetadata {
     default_text: CString,
-    _interop: Box<TextMetadata>,
+    interop: Box<TextMetadata>,
   }
 
   impl Interoperable for OwnedTextMetadata {
     fn as_ptr(&self) -> *const c_void {
-      &(*self._interop) as *const TextMetadata as *const c_void
+      &(*self.interop) as *const TextMetadata as *const c_void
     }
   }
 
@@ -255,13 +255,13 @@ mod interop {
     fn from(text_metadata: types::TextMetadata) -> Self {
       let default_text = CString::new(text_metadata.default_text)
         .expect("unable to convert default text to CString");
-      let _interop = Box::new(TextMetadata {
+      let interop = Box::new(TextMetadata {
         defaultText: default_text.as_ptr(),
         multiline: i32::from(text_metadata.multiline),
       });
       Self {
         default_text,
-        _interop,
+        interop,
       }
     }
   }
@@ -270,12 +270,12 @@ mod interop {
     values: Vec<CString>,
     values_ptr_array: Vec<*const c_char>,
     default_value: CString,
-    _interop: Box<ChoiceMetadata>,
+    interop: Box<ChoiceMetadata>,
   }
 
   impl Interoperable for OwnedChoiceMetadata {
     fn as_ptr(&self) -> *const c_void {
-      &(*self._interop) as *const ChoiceMetadata as *const c_void
+      &(*self.interop) as *const ChoiceMetadata as *const c_void
     }
   }
 
@@ -298,7 +298,7 @@ mod interop {
       let default_value =
         CString::new(metadata.default_value).expect("unable to convert default value to CString");
 
-      let _interop = Box::new(ChoiceMetadata {
+      let interop = Box::new(ChoiceMetadata {
         values: values_ptr_array.as_ptr(),
         valueSize: values.len() as c_int,
         choiceType: choice_type,
@@ -308,7 +308,7 @@ mod interop {
         values,
         values_ptr_array,
         default_value,
-        _interop,
+        interop,
       }
     }
   }
@@ -316,13 +316,13 @@ mod interop {
   struct OwnedRowMetadata {
     fields: Vec<OwnedField>,
 
-    _metadata: Vec<FieldMetadata>,
-    _interop: Box<RowMetadata>,
+    metadata: Vec<FieldMetadata>,
+    interop: Box<RowMetadata>,
   }
 
   impl Interoperable for OwnedRowMetadata {
     fn as_ptr(&self) -> *const c_void {
-      &(*self._interop) as *const RowMetadata as *const c_void
+      &(*self.interop) as *const RowMetadata as *const c_void
     }
   }
 
@@ -330,20 +330,20 @@ mod interop {
     fn from(row_metadata: types::RowMetadata) -> Self {
       let fields: Vec<OwnedField> = row_metadata.fields.into_iter().map(Into::into).collect();
 
-      let _metadata: Vec<FieldMetadata> = fields
+      let metadata: Vec<FieldMetadata> = fields
         .iter()
         .map(sys::form::interop::OwnedField::metadata)
         .collect();
 
-      let _interop = Box::new(RowMetadata {
-        fields: _metadata.as_ptr(),
-        fieldSize: _metadata.len() as c_int,
+      let interop = Box::new(RowMetadata {
+        fields: metadata.as_ptr(),
+        fieldSize: metadata.len() as c_int,
       });
 
       Self {
         fields,
-        _metadata,
-        _interop,
+        metadata,
+        interop,
       }
     }
   }

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -125,7 +125,7 @@ mod interop {
       let icon_path = if let Some(icon_path) = form.icon.as_ref() {
         icon_path.clone()
       } else {
-        "".to_owned()
+        String::new()
       };
 
       let icon_path = CString::new(icon_path).expect("unable to convert form icon to CString");

--- a/espanso-modulo/src/sys/search/mod.rs
+++ b/espanso-modulo/src/sys/search/mod.rs
@@ -41,6 +41,8 @@ pub mod types {
 
 #[allow(dead_code)]
 mod interop {
+  use crate::sys;
+
   use super::super::interop::*;
   use super::types;
   use std::ffi::{c_void, CString};
@@ -65,9 +67,12 @@ mod interop {
       let title =
         CString::new(search.title.clone()).expect("unable to convert search title to CString");
 
-      let items: Vec<OwnedSearchItem> = search.items.iter().map(|item| item.into()).collect();
+      let items: Vec<OwnedSearchItem> = search.items.iter().map(Into::into).collect();
 
-      let interop_items: Vec<SearchItem> = items.iter().map(|item| item.to_search_item()).collect();
+      let interop_items: Vec<SearchItem> = items
+        .iter()
+        .map(sys::search::interop::OwnedSearchItem::to_search_item)
+        .collect();
 
       let icon_path = if let Some(icon_path) = search.icon.as_ref() {
         icon_path.clone()

--- a/espanso-modulo/src/sys/search/mod.rs
+++ b/espanso-modulo/src/sys/search/mod.rs
@@ -144,7 +144,7 @@ mod interop {
       let trigger = if let Some(trigger) = item.trigger.as_deref() {
         CString::new(trigger.to_string()).expect("unable to convert item trigger to CString")
       } else {
-        CString::new("".to_string()).expect("unable to convert item trigger to CString")
+        CString::new(String::new()).expect("unable to convert item trigger to CString")
       };
 
       Self { id, label, trigger }

--- a/espanso-modulo/src/sys/search/mod.rs
+++ b/espanso-modulo/src/sys/search/mod.rs
@@ -53,12 +53,12 @@ mod interop {
     hint: CString,
     items: Vec<OwnedSearchItem>,
     pub(crate) interop_items: Vec<SearchItem>,
-    _interop: Box<SearchMetadata>,
+    interop: Box<SearchMetadata>,
   }
 
   impl Interoperable for OwnedSearch {
     fn as_ptr(&self) -> *const c_void {
-      &(*self._interop) as *const SearchMetadata as *const c_void
+      &(*self.interop) as *const SearchMetadata as *const c_void
     }
   }
 
@@ -102,7 +102,7 @@ mod interop {
         std::ptr::null()
       };
 
-      let _interop = Box::new(SearchMetadata {
+      let interop = Box::new(SearchMetadata {
         iconPath: icon_path_ptr,
         windowTitle: title.as_ptr(),
         hintText: hint_ptr,
@@ -114,7 +114,7 @@ mod interop {
         hint,
         items,
         interop_items,
-        _interop,
+        interop,
       }
     }
   }

--- a/espanso-modulo/src/sys/search/mod.rs
+++ b/espanso-modulo/src/sys/search/mod.rs
@@ -77,7 +77,7 @@ mod interop {
       let icon_path = if let Some(icon_path) = search.icon.as_ref() {
         icon_path.clone()
       } else {
-        "".to_owned()
+        String::new()
       };
 
       let icon_path = CString::new(icon_path).expect("unable to convert search icon to CString");
@@ -91,7 +91,7 @@ mod interop {
       let hint = if let Some(hint) = search.hint.as_ref() {
         hint.clone()
       } else {
-        "".to_owned()
+        String::new()
       };
 
       let hint = CString::new(hint).expect("unable to convert search icon to CString");

--- a/espanso-modulo/src/sys/troubleshooting/mod.rs
+++ b/espanso-modulo/src/sys/troubleshooting/mod.rs
@@ -45,7 +45,7 @@ mod interop {
   pub(crate) struct OwnedErrorSet {
     file_path: Option<CString>,
     errors: Vec<OwnedErrorMetadata>,
-    pub(crate) _interop_errors: Vec<ErrorMetadata>,
+    pub(crate) interop_errors: Vec<ErrorMetadata>,
   }
 
   impl OwnedErrorSet {
@@ -58,8 +58,8 @@ mod interop {
 
       ErrorSetMetadata {
         file_path: file_path_ptr,
-        errors: self._interop_errors.as_ptr(),
-        errors_count: self._interop_errors.len() as c_int,
+        errors: self.interop_errors.as_ptr(),
+        errors_count: self.interop_errors.len() as c_int,
       }
     }
   }
@@ -73,13 +73,13 @@ mod interop {
 
       let errors: Vec<OwnedErrorMetadata> = error_set.errors.iter().map(Into::into).collect();
 
-      let _interop_errors: Vec<ErrorMetadata> =
+      let interop_errors: Vec<ErrorMetadata> =
         errors.iter().map(|item| item.to_error_metadata()).collect();
 
       Self {
         file_path,
         errors,
-        _interop_errors,
+        interop_errors,
       }
     }
   }

--- a/espanso-modulo/src/sys/troubleshooting/mod.rs
+++ b/espanso-modulo/src/sys/troubleshooting/mod.rs
@@ -22,6 +22,7 @@ use std::os::raw::{c_char, c_int};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+use crate::sys;
 use crate::sys::interop::{ErrorSetMetadata, TroubleshootingMetadata};
 use crate::sys::troubleshooting::interop::OwnedErrorSet;
 use crate::sys::util::convert_to_cstring_or_null;
@@ -70,8 +71,7 @@ mod interop {
           .expect("unable to convert file_path to CString")
       });
 
-      let errors: Vec<OwnedErrorMetadata> =
-        error_set.errors.iter().map(|item| item.into()).collect();
+      let errors: Vec<OwnedErrorMetadata> = error_set.errors.iter().map(Into::into).collect();
 
       let _interop_errors: Vec<ErrorMetadata> =
         errors.iter().map(|item| item.to_error_metadata()).collect();
@@ -118,11 +118,10 @@ pub fn show(options: TroubleshootingOptions) -> Result<()> {
   let (_c_window_icon_path, c_window_icon_path_ptr) =
     convert_to_cstring_or_null(options.window_icon_path);
 
-  let owned_error_sets: Vec<OwnedErrorSet> =
-    options.error_sets.iter().map(|set| set.into()).collect();
+  let owned_error_sets: Vec<OwnedErrorSet> = options.error_sets.iter().map(Into::into).collect();
   let error_sets: Vec<ErrorSetMetadata> = owned_error_sets
     .iter()
-    .map(|set| set.to_error_set_metadata())
+    .map(sys::troubleshooting::interop::OwnedErrorSet::to_error_set_metadata)
     .collect();
 
   extern "C" fn dont_show_again_changed(dont_show: c_int) {

--- a/espanso-modulo/src/sys/troubleshooting/mod.rs
+++ b/espanso-modulo/src/sys/troubleshooting/mod.rs
@@ -151,7 +151,7 @@ pub fn show(options: TroubleshootingOptions) -> Result<()> {
 
   {
     let mut lock = HANDLERS.lock().expect("unable to acquire handlers lock");
-    *lock = Some(options.handlers)
+    *lock = Some(options.handlers);
   }
 
   let troubleshooting_metadata = TroubleshootingMetadata {

--- a/espanso-modulo/src/sys/welcome/mod.rs
+++ b/espanso-modulo/src/sys/welcome/mod.rs
@@ -49,7 +49,7 @@ pub fn show(options: WelcomeOptions) {
 
   {
     let mut lock = HANDLERS.lock().expect("unable to acquire handlers lock");
-    *lock = Some(options.handlers)
+    *lock = Some(options.handlers);
   }
 
   let welcome_metadata = WelcomeMetadata {

--- a/espanso-modulo/src/sys/wizard/mod.rs
+++ b/espanso-modulo/src/sys/wizard/mod.rs
@@ -132,13 +132,13 @@ pub fn show(options: WizardOptions) -> bool {
       .expect("unable to acquire lock in on_completed method");
     let handlers_ref = (*lock).as_ref().expect("unable to unwrap handlers");
     if let Some(handler_ref) = handlers_ref.on_completed.as_ref() {
-      (*handler_ref)()
+      (*handler_ref)();
     }
   }
 
   {
     let mut lock = HANDLERS.lock().expect("unable to acquire handlers lock");
-    *lock = Some(options.handlers)
+    *lock = Some(options.handlers);
   }
 
   let wizard_metadata = WizardMetadata {

--- a/espanso-package/src/archive/mod.rs
+++ b/espanso-package/src/archive/mod.rs
@@ -93,7 +93,7 @@ impl std::fmt::Display for PackageSource {
         repo_url,
         repo_branch: _,
         use_native_git: _,
-      } => write!(f, "git: {}", repo_url),
+      } => write!(f, "git: {repo_url}"),
     }
   }
 }

--- a/espanso-package/src/provider/git.rs
+++ b/espanso-package/src/provider/git.rs
@@ -60,9 +60,8 @@ impl GitPackageProvider {
     if !output.status.success() {
       let stderr = String::from_utf8_lossy(&output.stderr);
       bail!("git command exited with non-zero status: {}", stderr);
-    } else {
-      Ok(())
     }
+    Ok(())
   }
 }
 

--- a/espanso-package/src/provider/hub.rs
+++ b/espanso-package/src/provider/hub.rs
@@ -109,12 +109,12 @@ impl EspansoHubPackageProvider {
       }
     }
 
-    let new_index = self.download_index()?;
+    let new_index = EspansoHubPackageProvider::download_index()?;
     self.save_index_to_cache(new_index.clone())?;
     Ok(new_index)
   }
 
-  fn download_index(&self) -> Result<PackageIndex> {
+  fn download_index() -> Result<PackageIndex> {
     info_println!("fetching package index...");
     let json_body = read_string_from_url(ESPANSO_HUB_PACKAGE_INDEX_URL)?;
 

--- a/espanso-package/src/resolver.rs
+++ b/espanso-package/src/resolver.rs
@@ -137,7 +137,7 @@ mod tests {
           },
           base_dir: base_dir.to_path_buf(),
         },]
-      )
+      );
     });
   }
 
@@ -227,7 +227,7 @@ mod tests {
             base_dir: sub_dir3,
           },
         ]
-      )
+      );
     });
   }
 

--- a/espanso-path/src/lib.rs
+++ b/espanso-path/src/lib.rs
@@ -55,10 +55,10 @@ pub fn resolve_paths(
     runtime_dir
   } else {
     // Create the runtime directory if not already present
-    let runtime_dir = if !is_portable_mode() {
-      get_default_runtime_path()
-    } else {
+    let runtime_dir = if is_portable_mode() {
       get_portable_runtime_path().expect("unable to obtain runtime directory path")
+    } else {
+      get_default_runtime_path()
     };
     info!("creating runtime directory in {:?}", runtime_dir);
     create_dir_all(&runtime_dir).expect("unable to create runtime directory");

--- a/espanso-render/src/extension/choice.rs
+++ b/espanso-render/src/extension/choice.rs
@@ -66,10 +66,10 @@ impl<'a> Extension for ChoiceExtension<'a> {
         .lines()
         .filter_map(|line| {
           let trimmed_line = line.trim();
-          if !trimmed_line.is_empty() {
-            Some(trimmed_line)
-          } else {
+          if trimmed_line.is_empty() {
             None
+          } else {
+            Some(trimmed_line)
           }
         })
         .map(|line| Choice {

--- a/espanso-render/src/extension/script.rs
+++ b/espanso-render/src/extension/script.rs
@@ -79,7 +79,7 @@ impl Extension for ScriptExtension {
         if cfg!(target_os = "windows") {
           let path = PathBuf::from(&arg);
           if path.exists() {
-            *arg = path.to_string_lossy().to_string()
+            *arg = path.to_string_lossy().to_string();
           }
         }
       });

--- a/espanso-render/src/extension/script.rs
+++ b/espanso-render/src/extension/script.rs
@@ -64,7 +64,7 @@ impl Extension for ScriptExtension {
       // Replace %HOME% with current user home directory to
       // create cross-platform paths. See issue #265
       // Also replace %CONFIG% and %PACKAGES% path. See issue #380
-      for arg in args.iter_mut() {
+      for arg in &mut args {
         if arg.contains("%HOME%") {
           *arg = arg.replace("%HOME%", &self.home_path.to_string_lossy());
         }

--- a/espanso-render/src/extension/script.rs
+++ b/espanso-render/src/extension/script.rs
@@ -64,7 +64,7 @@ impl Extension for ScriptExtension {
       // Replace %HOME% with current user home directory to
       // create cross-platform paths. See issue #265
       // Also replace %CONFIG% and %PACKAGES% path. See issue #380
-      args.iter_mut().for_each(|arg| {
+      for arg in args.iter_mut() {
         if arg.contains("%HOME%") {
           *arg = arg.replace("%HOME%", &self.home_path.to_string_lossy());
         }
@@ -82,7 +82,7 @@ impl Extension for ScriptExtension {
             *arg = path.to_string_lossy().to_string();
           }
         }
-      });
+      }
 
       let mut command = Command::new(&args[0]);
       command.env("CONFIG", self.config_path.to_string_lossy().to_string());

--- a/espanso-render/src/extension/script.rs
+++ b/espanso-render/src/extension/script.rs
@@ -328,7 +328,7 @@ mod tests {
         .calculate(&Default::default(), &Default::default(), &param)
         .into_success()
         .unwrap(),
-      ExtensionOutput::Single("".to_string())
+      ExtensionOutput::Single(String::new())
     );
   }
 }

--- a/espanso-render/src/extension/shell.rs
+++ b/espanso-render/src/extension/shell.rs
@@ -123,7 +123,7 @@ impl Shell {
       let mut tokens: Vec<&str> = vec!["CONFIG/p"];
 
       // Add all the previous variables
-      for (key, _) in vars {
+      for key in vars.keys() {
         tokens.push(key);
       }
 

--- a/espanso-render/src/extension/shell.rs
+++ b/espanso-render/src/extension/shell.rs
@@ -91,7 +91,7 @@ impl Shell {
     super::util::set_command_flags(&mut command);
 
     // Inject all the previous variables
-    for (key, value) in vars.iter() {
+    for (key, value) in vars {
       command.env(key, value);
     }
 
@@ -123,7 +123,7 @@ impl Shell {
       let mut tokens: Vec<&str> = vec!["CONFIG/p"];
 
       // Add all the previous variables
-      for (key, _) in vars.iter() {
+      for (key, _) in vars {
         tokens.push(key);
       }
 

--- a/espanso-render/src/extension/util.rs
+++ b/espanso-render/src/extension/util.rs
@@ -46,7 +46,7 @@ pub fn set_command_flags(command: &mut Command) {
   use std::os::windows::process::CommandExt;
   // Avoid showing the shell window
   // See: https://github.com/federico-terzi/espanso/issues/249
-  command.creation_flags(0x08000000);
+  command.creation_flags(0x0800_0000);
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/espanso-render/src/extension/util.rs
+++ b/espanso-render/src/extension/util.rs
@@ -23,14 +23,14 @@ use std::{collections::HashMap, process::Command};
 pub fn convert_to_env_variables(scope: &Scope) -> HashMap<String, String> {
   let mut output = HashMap::new();
 
-  for (key, result) in scope.iter() {
+  for (key, result) in scope {
     match result {
       ExtensionOutput::Single(value) => {
         let name = format!("ESPANSO_{}", key.to_uppercase());
         output.insert(name, value.clone());
       }
       ExtensionOutput::Multiple(values) => {
-        for (sub_key, sub_value) in values.iter() {
+        for (sub_key, sub_value) in values {
           let name = format!("ESPANSO_{}_{}", key.to_uppercase(), sub_key.to_uppercase());
           output.insert(name, sub_value.clone());
         }

--- a/espanso-render/src/lib.rs
+++ b/espanso-render/src/lib.rs
@@ -89,8 +89,8 @@ pub struct Variable {
 impl Default for Variable {
   fn default() -> Self {
     Self {
-      name: "".to_string(),
-      var_type: "".to_string(),
+      name: String::new(),
+      var_type: String::new(),
       inject_vars: true,
       params: Params::new(),
       depends_on: Vec::new(),

--- a/espanso-render/src/renderer/mod.rs
+++ b/espanso-render/src/renderer/mod.rs
@@ -197,7 +197,7 @@ impl<'a> Renderer for DefaultRenderer<'a> {
               let capitalized_word: String = v.into_iter().collect();
               capitalized_word
             } else {
-              "".to_string()
+              String::new()
             }
           })
           .to_string()

--- a/espanso-render/src/renderer/resolve.rs
+++ b/espanso-render/src/renderer/resolve.rs
@@ -56,7 +56,7 @@ pub(crate) fn resolve_evaluation_order<'a>(
   let eval_order_ref = eval_order.borrow();
 
   let mut ordered_variables = Vec::new();
-  for var_name in (*eval_order_ref).iter() {
+  for var_name in &(*eval_order_ref) {
     let node = node_map
       .get(var_name)
       .ok_or_else(|| anyhow!("could not find dependency node for variable: {}", var_name))?;
@@ -116,7 +116,7 @@ fn generate_nodes<'a>(
   global_vars_nodes.into_iter().for_each(|node| {
     node_map.insert(node.name, node);
   });
-  for node in local_vars_nodes.into_iter() {
+  for node in local_vars_nodes {
     node_map.insert(node.name, node);
   }
 
@@ -158,7 +158,7 @@ fn resolve_dependencies<'a>(
   }
 
   if let Some(dependencies) = &node.dependencies {
-    for dependency in dependencies.iter() {
+    for dependency in dependencies {
       let has_been_resolved = {
         let resolved_ref = resolved.borrow();
         resolved_ref.contains(dependency)

--- a/espanso-render/src/renderer/resolve.rs
+++ b/espanso-render/src/renderer/resolve.rs
@@ -116,9 +116,9 @@ fn generate_nodes<'a>(
   global_vars_nodes.into_iter().for_each(|node| {
     node_map.insert(node.name, node);
   });
-  local_vars_nodes.into_iter().for_each(|node| {
+  for node in local_vars_nodes.into_iter() {
     node_map.insert(node.name, node);
-  });
+  }
 
   node_map
 }

--- a/espanso-render/src/renderer/resolve.rs
+++ b/espanso-render/src/renderer/resolve.rs
@@ -128,7 +128,7 @@ fn create_node_from_var(var: &Variable) -> Node {
     let mut vars = HashSet::new();
 
     if var.inject_vars {
-      vars.extend(super::util::get_params_variable_names(&var.params))
+      vars.extend(super::util::get_params_variable_names(&var.params));
     }
 
     vars.extend(var.depends_on.iter().map(|s| s.as_str()));
@@ -177,7 +177,7 @@ fn resolve_dependencies<'a>(
 
         match node_map.get(dependency) {
           Some(dependency_node) => {
-            resolve_dependencies(dependency_node, node_map, eval_order, resolved, seen)?
+            resolve_dependencies(dependency_node, node_map, eval_order, resolved, seen)?;
           }
           None => {
             error!("could not resolve variable {:?}", dependency);

--- a/espanso-render/src/renderer/resolve.rs
+++ b/espanso-render/src/renderer/resolve.rs
@@ -79,7 +79,7 @@ fn generate_nodes<'a>(
     if var.inject_vars {
       dependencies.extend(super::util::get_params_variable_names(&var.params));
     }
-    dependencies.extend(var.depends_on.iter().map(|v| v.as_str()));
+    dependencies.extend(var.depends_on.iter().map(String::as_str));
 
     // Every local variable depends on the one before it.
     // Needed to guarantee execution order within local vars.
@@ -131,7 +131,7 @@ fn create_node_from_var(var: &Variable) -> Node {
       vars.extend(super::util::get_params_variable_names(&var.params));
     }
 
-    vars.extend(var.depends_on.iter().map(|s| s.as_str()));
+    vars.extend(var.depends_on.iter().map(String::as_str));
 
     Some(vars)
   } else {

--- a/espanso-render/src/renderer/util.rs
+++ b/espanso-render/src/renderer/util.rs
@@ -81,13 +81,9 @@ pub(crate) fn render_variables(body: &str, scope: &Scope) -> Result<String> {
               results.get(var_subname).map_or("", |value| value)
             }
             None => {
-              error!(
-                "nested name missing from multi-value variable: {}",
-                var_name
-              );
+              error!("nested name missing from multi-value variable: {var_name}");
               replacing_error = Some(RendererError::MissingVariable(format!(
-                "nested name missing from multi-value variable: {}",
-                var_name
+                "nested name missing from multi-value variable: {var_name}"
               )));
               ""
             }
@@ -95,8 +91,7 @@ pub(crate) fn render_variables(body: &str, scope: &Scope) -> Result<String> {
         },
         None => {
           replacing_error = Some(RendererError::MissingVariable(format!(
-            "variable '{}' is missing",
-            var_name
+            "variable '{var_name}' is missing"
           )));
           ""
         }

--- a/espanso-render/src/renderer/util.rs
+++ b/espanso-render/src/renderer/util.rs
@@ -37,7 +37,7 @@ pub(crate) fn get_body_variable_names(body: &str) -> HashSet<&str> {
 pub(crate) fn get_params_variable_names(params: &Params) -> HashSet<&str> {
   let mut names = HashSet::new();
 
-  for (_, value) in params.iter() {
+  for value in params.values() {
     let local_names = get_value_variable_names_recursively(value);
     names.extend(local_names);
   }
@@ -114,7 +114,7 @@ pub(crate) fn unescape_variable_inections(body: &str) -> String {
 pub(crate) fn inject_variables_into_params(params: &Params, scope: &Scope) -> Result<Params> {
   let mut params = params.clone();
 
-  for (_, value) in params.iter_mut() {
+  for value in &mut params.values_mut() {
     inject_variables_into_value(value, scope)?;
   }
 

--- a/espanso-ui/src/win32/mod.rs
+++ b/espanso-ui/src/win32/mod.rs
@@ -199,9 +199,10 @@ impl UIEventLoop for Win32EventLoop {
   fn run(&self, event_callback: UIEventCallback) -> Result<()> {
     // Make sure the run() method is called in the same thread as initialize()
     if let Some(init_id) = self._init_thread_id.borrow() {
-      if init_id != &std::thread::current().id() {
-        panic!("Win32EventLoop run() and initialize() methods should be called in the same thread");
-      }
+      assert!(
+        !(init_id != &std::thread::current().id()),
+        "Win32EventLoop run() and initialize() methods should be called in the same thread"
+      );
     }
 
     let window_handle = self.handle.load(Ordering::Acquire);

--- a/espanso-ui/src/win32/mod.rs
+++ b/espanso-ui/src/win32/mod.rs
@@ -91,9 +91,7 @@ pub fn create(options: Win32UIOptions) -> Result<(Win32Remote, Win32EventLoop)> 
   let handle: Arc<AtomicPtr<c_void>> = Arc::new(AtomicPtr::new(std::ptr::null_mut()));
 
   // Validate icons
-  if options.icon_paths.len() > MAX_ICON_COUNT {
-    panic!("Win32 UI received too many icon paths, please increase the MAX_ICON_COUNT constant to support more");
-  }
+  assert!(options.icon_paths.len() <= MAX_ICON_COUNT, "Win32 UI received too many icon paths, please increase the MAX_ICON_COUNT constant to support more");
 
   // Convert the icon paths to the internal representation
   let mut icon_indexes: HashMap<TrayIcon, usize> = HashMap::new();

--- a/espanso-ui/src/win32/mod.rs
+++ b/espanso-ui/src/win32/mod.rs
@@ -220,7 +220,7 @@ impl UIEventLoop for Win32EventLoop {
       if let Some(callback) = unsafe { (*_self)._event_callback.borrow() } {
         let event: Option<UIEvent> = event.into();
         if let Some(event) = event {
-          callback(event)
+          callback(event);
         } else {
           trace!("Unable to convert raw event to input event");
         }

--- a/espanso-ui/src/win32/notification.rs
+++ b/espanso-ui/src/win32/notification.rs
@@ -91,7 +91,7 @@ pub fn show_notification(msg: &str) -> Result<()> {
 fn is_espanso_app_user_model_id_set() -> bool {
   match Command::new("powershell")
     .args(["-c", "get-startapps"])
-    .creation_flags(0x08000000)
+    .creation_flags(0x0800_0000)
     .output()
   {
     Ok(output) => {

--- a/espanso/src/cli/cmd.rs
+++ b/espanso/src/cli/cmd.rs
@@ -55,7 +55,7 @@ fn cmd_main(args: CliModuleArgs) -> i32 {
   };
 
   if let Err(error) = send_event_to_worker(&paths.runtime, event) {
-    eprintln!("unable to send command, error: {:?}", error);
+    eprintln!("unable to send command, error: {error:?}");
     return 2;
   }
 

--- a/espanso/src/cli/daemon/keyboard_layout_watcher.rs
+++ b/espanso/src/cli/daemon/keyboard_layout_watcher.rs
@@ -42,7 +42,7 @@ fn watcher_main(watcher_notify: &Sender<()>) {
   let mut layout = espanso_detect::get_active_layout();
 
   if layout.is_none() {
-    warn!("keyboard layout watcher couldn't determine active layout.")
+    warn!("keyboard layout watcher couldn't determine active layout.");
   }
 
   loop {

--- a/espanso/src/cli/daemon/mod.rs
+++ b/espanso/src/cli/daemon/mod.rs
@@ -89,6 +89,9 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
   // When a guard is dropped, the troubleshooting GUI is killed
   // so this ensures that there is only one troubleshooter running
   // at a given time.
+  //
+  // it is currently unused
+  // #[allow(unused_variables)]
   let mut _current_troubleshoot_guard = None;
 
   let (watcher_notify, watcher_signal) = unbounded::<()>();
@@ -96,14 +99,14 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
   watcher::initialize_and_spawn(&paths.config, watcher_notify)
     .expect("unable to initialize config watcher thread");
 
-  let (_keyboard_layout_watcher_notify, keyboard_layout_watcher_signal) = unbounded::<()>();
+  let (keyboard_layout_watcher_notify, keyboard_layout_watcher_signal) = unbounded::<()>();
 
   #[allow(clippy::redundant_clone)]
   // IMPORTANT: Here we clone the channel instead of simply passing it to avoid
   // dropping the channel immediately on those platforms that don't support the
   // layout watcher (currently Windows and macOS).
   // Otherwise, the select below would always return an error because the channel is closed.
-  keyboard_layout_watcher::initialize_and_spawn(_keyboard_layout_watcher_notify.clone()) // DON'T REMOVE THE CLONE!
+  keyboard_layout_watcher::initialize_and_spawn(keyboard_layout_watcher_notify.clone()) // DON'T REMOVE THE CLONE!
     .expect("unable to initialize keyboard layout watcher thread");
 
   let config_store =

--- a/espanso/src/cli/daemon/mod.rs
+++ b/espanso/src/cli/daemon/mod.rs
@@ -110,7 +110,7 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
     match troubleshoot::load_config_or_troubleshoot_until_config_is_correct_or_abort(
       &paths,
       &paths_overrides,
-      &watcher_signal,
+      watcher_signal.clone(),
     ) {
       Ok((result, guard)) => {
         _current_troubleshoot_guard = guard;

--- a/espanso/src/cli/daemon/mod.rs
+++ b/espanso/src/cli/daemon/mod.rs
@@ -316,9 +316,9 @@ fn restart_worker(
     std::thread::sleep(std::time::Duration::from_millis(100));
   }
 
-  if !has_timed_out {
-    spawn_worker(paths_overrides, exit_notify, start_reason);
-  } else {
+  if has_timed_out {
     error!("could not restart worker, as the exit process has timed out");
+  } else {
+    spawn_worker(paths_overrides, exit_notify, start_reason);
   }
 }

--- a/espanso/src/cli/daemon/mod.rs
+++ b/espanso/src/cli/daemon/mod.rs
@@ -110,7 +110,7 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
     match troubleshoot::load_config_or_troubleshoot_until_config_is_correct_or_abort(
       &paths,
       &paths_overrides,
-      watcher_signal.clone(),
+      &watcher_signal,
     ) {
       Ok((result, guard)) => {
         _current_troubleshoot_guard = guard;

--- a/espanso/src/cli/daemon/troubleshoot.rs
+++ b/espanso/src/cli/daemon/troubleshoot.rs
@@ -110,12 +110,12 @@ pub fn load_config_or_troubleshoot_until_config_is_correct_or_abort(
   paths_overrides: &PathsOverrides,
   watcher_receiver: Receiver<()>,
 ) -> Result<(ConfigLoadResult, Option<TroubleshootGuard>)> {
-  let mut _troubleshoot_guard = None;
+  let mut troubleshoot_guard = None;
 
   loop {
     // If the loading process is fatal, we keep showing the troubleshooter until
     // either the config is correct or the user aborts by closing the troubleshooter
-    _troubleshoot_guard = match load_config_or_troubleshoot(paths, paths_overrides) {
+    troubleshoot_guard = match load_config_or_troubleshoot(paths, paths_overrides) {
       LoadResult::Correct(result) => return Ok((result, None)),
       LoadResult::Warning(result, guard) => return Ok((result, guard)),
       LoadResult::Fatal(guard) => Some(guard),
@@ -129,7 +129,7 @@ pub fn load_config_or_troubleshoot_until_config_is_correct_or_abort(
           break
         },
         default(Duration::from_millis(500)) => {
-          if let Some(guard) = &mut _troubleshoot_guard {
+          if let Some(guard) = &mut troubleshoot_guard {
             if let Ok(ended) = guard.try_wait() {
               if ended {
                 bail!("user aborted troubleshooter");

--- a/espanso/src/cli/daemon/troubleshoot.rs
+++ b/espanso/src/cli/daemon/troubleshoot.rs
@@ -110,12 +110,12 @@ pub fn load_config_or_troubleshoot_until_config_is_correct_or_abort(
   paths_overrides: &PathsOverrides,
   watcher_receiver: Receiver<()>,
 ) -> Result<(ConfigLoadResult, Option<TroubleshootGuard>)> {
-  let mut troubleshoot_guard = None;
+  let mut _troubleshoot_guard = None;
 
   loop {
     // If the loading process is fatal, we keep showing the troubleshooter until
     // either the config is correct or the user aborts by closing the troubleshooter
-    troubleshoot_guard = match load_config_or_troubleshoot(paths, paths_overrides) {
+    _troubleshoot_guard = match load_config_or_troubleshoot(paths, paths_overrides) {
       LoadResult::Correct(result) => return Ok((result, None)),
       LoadResult::Warning(result, guard) => return Ok((result, guard)),
       LoadResult::Fatal(guard) => Some(guard),
@@ -129,7 +129,7 @@ pub fn load_config_or_troubleshoot_until_config_is_correct_or_abort(
           break
         },
         default(Duration::from_millis(500)) => {
-          if let Some(guard) = &mut troubleshoot_guard {
+          if let Some(guard) = &mut _troubleshoot_guard {
             if let Ok(ended) = guard.try_wait() {
               if ended {
                 bail!("user aborted troubleshooter");

--- a/espanso/src/cli/daemon/troubleshoot.rs
+++ b/espanso/src/cli/daemon/troubleshoot.rs
@@ -108,7 +108,7 @@ pub fn load_config_or_troubleshoot(paths: &Paths, paths_overrides: &PathsOverrid
 pub fn load_config_or_troubleshoot_until_config_is_correct_or_abort(
   paths: &Paths,
   paths_overrides: &PathsOverrides,
-  watcher_receiver: &Receiver<()>,
+  watcher_receiver: Receiver<()>,
 ) -> Result<(ConfigLoadResult, Option<TroubleshootGuard>)> {
   let mut _troubleshoot_guard = None;
 

--- a/espanso/src/cli/daemon/troubleshoot.rs
+++ b/espanso/src/cli/daemon/troubleshoot.rs
@@ -108,7 +108,7 @@ pub fn load_config_or_troubleshoot(paths: &Paths, paths_overrides: &PathsOverrid
 pub fn load_config_or_troubleshoot_until_config_is_correct_or_abort(
   paths: &Paths,
   paths_overrides: &PathsOverrides,
-  watcher_receiver: Receiver<()>,
+  watcher_receiver: &Receiver<()>,
 ) -> Result<(ConfigLoadResult, Option<TroubleshootGuard>)> {
   let mut _troubleshoot_guard = None;
 

--- a/espanso/src/cli/daemon/watcher.rs
+++ b/espanso/src/cli/daemon/watcher.rs
@@ -48,7 +48,7 @@ pub fn initialize_and_spawn(config_dir: &Path, watcher_notify: Sender<()>) -> Re
   Ok(())
 }
 
-fn watcher_main(config_dir: &Path, debounce_tx: crossbeam::channel::Sender<()>) {
+fn watcher_main(config_dir: &Path, debounce_tx: Sender<()>) {
   let (tx, rx) = std::sync::mpsc::channel();
 
   let mut watcher: RecommendedWatcher =

--- a/espanso/src/cli/edit.rs
+++ b/espanso/src/cli/edit.rs
@@ -156,9 +156,9 @@ fn determine_target_path(config_path: &Path, target_file: Option<&str>) -> PathB
       custom => {
         if !custom.ends_with(".yml") && !custom.ends_with(".yaml") {
           if espanso_config::is_legacy_config(config_path) {
-            config_path.join("user").join(format!("{}.yml", custom))
+            config_path.join("user").join(format!("{custom}.yml"))
           } else {
-            config_path.join("match").join(format!("{}.yml", custom))
+            config_path.join("match").join(format!("{custom}.yml"))
           }
         } else {
           config_path.join(custom)

--- a/espanso/src/cli/edit.rs
+++ b/espanso/src/cli/edit.rs
@@ -48,12 +48,11 @@ fn edit_main(args: CliModuleArgs) -> i32 {
   let paths = args.paths.expect("missing paths argument");
   let cli_args = args.cli_args.expect("missing cli_args");
 
-  if !paths.config.is_dir() {
-    panic!(
-      "config directory does not exist in path: {:?}",
-      paths.config
-    );
-  }
+  assert!(
+    paths.config.is_dir(),
+    "config directory does not exist in path: {:?}",
+    paths.config
+  );
 
   // Determine which is the file to edit
   let target_file = cli_args.value_of("target_file");

--- a/espanso/src/cli/env_path.rs
+++ b/espanso/src/cli/env_path.rs
@@ -41,16 +41,14 @@ fn env_path_main(args: CliModuleArgs) -> i32 {
   if cli_args.subcommand_matches("register").is_some() {
     if let Err(error) = crate::path::add_espanso_to_path(elevated_priviledge_prompt) {
       error_print_and_log(&format!(
-        "Unable to add 'espanso' command to PATH: {:?}",
-        error
+        "Unable to add 'espanso' command to PATH: {error:?}"
       ));
       return ADD_TO_PATH_FAILURE;
     }
   } else if cli_args.subcommand_matches("unregister").is_some() {
     if let Err(error) = crate::path::remove_espanso_from_path(elevated_priviledge_prompt) {
       error_print_and_log(&format!(
-        "Unable to remove 'espanso' command from PATH: {:?}",
-        error
+        "Unable to remove 'espanso' command from PATH: {error:?}"
       ));
       return ADD_TO_PATH_FAILURE;
     }
@@ -63,6 +61,6 @@ fn env_path_main(args: CliModuleArgs) -> i32 {
 }
 
 fn error_print_and_log(msg: &str) {
-  error!("{}", msg);
-  eprintln!("{}", msg);
+  error!("{msg}");
+  eprintln!("{msg}");
 }

--- a/espanso/src/cli/launcher/mod.rs
+++ b/espanso/src/cli/launcher/mod.rs
@@ -104,7 +104,7 @@ fn launcher_main(args: CliModuleArgs) -> i32 {
       match util::configure_auto_start(true) {
         Ok(_) => true,
         Err(error) => {
-          eprintln!("Service register returned error: {}", error);
+          eprintln!("Service register returned error: {error}");
           false
         }
       }
@@ -128,7 +128,7 @@ fn launcher_main(args: CliModuleArgs) -> i32 {
   let add_to_path_handler = Box::new(move || match util::add_espanso_to_path() {
     Ok(_) => true,
     Err(error) => {
-      eprintln!("Add to path returned error: {}", error);
+      eprintln!("Add to path returned error: {error}");
       false
     }
   });

--- a/espanso/src/cli/log.rs
+++ b/espanso/src/cli/log.rs
@@ -44,7 +44,7 @@ fn log_main(args: CliModuleArgs) -> i32 {
   if let Ok(log_file) = log_file {
     let reader = BufReader::new(log_file);
     for line in reader.lines().flatten() {
-      println!("{}", line);
+      println!("{line}");
     }
   } else {
     eprintln!("Error reading log file");

--- a/espanso/src/cli/match_cli/exec.rs
+++ b/espanso/src/cli/match_cli/exec.rs
@@ -55,7 +55,7 @@ pub fn exec_main(cli_args: &ArgMatches, paths: &Paths) -> Result<()> {
           arg
         );
       }
-    })
+    });
   }
 
   client

--- a/espanso/src/cli/match_cli/exec.rs
+++ b/espanso/src/cli/match_cli/exec.rs
@@ -50,10 +50,7 @@ pub fn exec_main(cli_args: &ArgMatches, paths: &Paths) -> Result<()> {
       if let Some((key, value)) = tokens {
         match_args.insert(key.to_string(), value.to_string());
       } else {
-        eprintln!(
-          "invalid format for argument '{}', you should follow the 'name=value' format",
-          arg
-        );
+        eprintln!("invalid format for argument '{arg}', you should follow the 'name=value' format");
       }
     });
   }

--- a/espanso/src/cli/match_cli/list.rs
+++ b/espanso/src/cli/match_cli/list.rs
@@ -59,12 +59,12 @@ pub fn print_matches_as_plain(match_list: &[&Match], only_triggers: bool, preser
 
     for trigger in triggers {
       if only_triggers {
-        println!("{}", trigger);
+        println!("{trigger}");
       } else {
         let description = m.description();
 
         if preserve_newlines {
-          println!("{} - {}", trigger, description);
+          println!("{trigger} - {description}");
         } else {
           println!("{} - {}", trigger, description.replace('\n', " "));
         }
@@ -96,7 +96,7 @@ pub fn print_matches_as_json(match_list: &[&Match]) -> Result<()> {
 
   let json = serde_json::to_string_pretty(&entries)?;
 
-  println!("{}", json);
+  println!("{json}");
 
   Ok(())
 }

--- a/espanso/src/cli/match_cli/list.rs
+++ b/espanso/src/cli/match_cli/list.rs
@@ -43,7 +43,7 @@ pub fn list_main(
   if cli_args.is_present("json") {
     print_matches_as_json(&match_set.matches)?;
   } else {
-    print_matches_as_plain(&match_set.matches, only_triggers, preserve_newlines)
+    print_matches_as_plain(&match_set.matches, only_triggers, preserve_newlines);
   }
 
   Ok(())
@@ -64,9 +64,9 @@ pub fn print_matches_as_plain(match_list: &[&Match], only_triggers: bool, preser
         let description = m.description();
 
         if preserve_newlines {
-          println!("{} - {}", trigger, description)
+          println!("{} - {}", trigger, description);
         } else {
-          println!("{} - {}", trigger, description.replace('\n', " "))
+          println!("{} - {}", trigger, description.replace('\n', " "));
         }
       }
     }
@@ -91,7 +91,7 @@ pub fn print_matches_as_json(match_list: &[&Match]) -> Result<()> {
     entries.push(JsonMatchEntry {
       triggers,
       replace: m.description().to_string(),
-    })
+    });
   }
 
   let json = serde_json::to_string_pretty(&entries)?;

--- a/espanso/src/cli/match_cli/mod.rs
+++ b/espanso/src/cli/match_cli/mod.rs
@@ -40,12 +40,12 @@ fn match_main(args: CliModuleArgs) -> i32 {
 
   if let Some(sub_args) = cli_args.subcommand_matches("list") {
     if let Err(err) = list::list_main(sub_args, config_store, match_store) {
-      eprintln!("unable to list matches: {:?}", err);
+      eprintln!("unable to list matches: {err:?}");
       return 1;
     }
   } else if let Some(sub_args) = cli_args.subcommand_matches("exec") {
     if let Err(err) = exec::exec_main(sub_args, &paths) {
-      eprintln!("unable to exec match: {:?}", err);
+      eprintln!("unable to exec match: {err:?}");
       return 1;
     }
   } else {

--- a/espanso/src/cli/migrate.rs
+++ b/espanso/src/cli/migrate.rs
@@ -174,7 +174,7 @@ fn find_available_backup_dir() -> PathBuf {
     let num = if i > 1 {
       format!("-{i}")
     } else {
-      "".to_string()
+      String::new()
     };
 
     let target_backup_dir = find_backup_dir_location().join(format!("espanso-migrate-backup{num}"));

--- a/espanso/src/cli/migrate.rs
+++ b/espanso/src/cli/migrate.rs
@@ -172,13 +172,12 @@ fn migrate_main(args: CliModuleArgs) -> i32 {
 fn find_available_backup_dir() -> PathBuf {
   for i in 1..20 {
     let num = if i > 1 {
-      format!("-{}", i)
+      format!("-{i}")
     } else {
       "".to_string()
     };
 
-    let target_backup_dir =
-      find_backup_dir_location().join(format!("espanso-migrate-backup{}", num));
+    let target_backup_dir = find_backup_dir_location().join(format!("espanso-migrate-backup{num}"));
 
     if !target_backup_dir.is_dir() {
       return target_backup_dir;
@@ -205,6 +204,6 @@ fn find_backup_dir_location() -> PathBuf {
 }
 
 fn error_print_and_log(msg: &str) {
-  error!("{}", msg);
-  eprintln!("{}", msg);
+  error!("{msg}");
+  eprintln!("{msg}");
 }

--- a/espanso/src/cli/mod.rs
+++ b/espanso/src/cli/mod.rs
@@ -59,7 +59,7 @@ impl Default for CliModule {
       disable_logs_terminal_output: false,
       requires_paths: false,
       requires_config: false,
-      subcommand: "".to_string(),
+      subcommand: String::new(),
       show_in_dock: false,
       requires_linux_capabilities: false,
       entry: |_| 0,

--- a/espanso/src/cli/modulo/form.rs
+++ b/espanso/src/cli/modulo/form.rs
@@ -54,7 +54,7 @@ pub fn form_main(matches: &ArgMatches, _icon_paths: &IconPaths) -> i32 {
   let values = show(form);
 
   let output = serde_json::to_string(&values).expect("unable to encode values as JSON");
-  println!("{}", output);
+  println!("{output}");
 
   0
 }

--- a/espanso/src/cli/modulo/form.rs
+++ b/espanso/src/cli/modulo/form.rs
@@ -38,10 +38,10 @@ pub fn form_main(matches: &ArgMatches, _icon_paths: &IconPaths) -> i32 {
     std::fs::read_to_string(input_file).expect("unable to read input file")
   };
 
-  let mut config: config::FormConfig = if !as_json {
-    serde_yaml::from_str(&data).expect("unable to parse form configuration")
-  } else {
+  let mut config: config::FormConfig = if as_json {
     serde_json::from_str(&data).expect("unable to parse form configuration")
+  } else {
+    serde_yaml::from_str(&data).expect("unable to parse form configuration")
   };
 
   // Overwrite the icon

--- a/espanso/src/cli/modulo/search.rs
+++ b/espanso/src/cli/modulo/search.rs
@@ -39,10 +39,10 @@ pub fn search_main(matches: &ArgMatches, icon_paths: &IconPaths) -> i32 {
     std::fs::read_to_string(input_file).expect("unable to read input file")
   };
 
-  let mut config: config::SearchConfig = if !as_json {
-    serde_yaml::from_str(&data).expect("unable to parse search configuration")
-  } else {
+  let mut config: config::SearchConfig = if as_json {
     serde_json::from_str(&data).expect("unable to parse search configuration")
+  } else {
+    serde_yaml::from_str(&data).expect("unable to parse search configuration")
   };
 
   // Overwrite the icon

--- a/espanso/src/cli/modulo/search.rs
+++ b/espanso/src/cli/modulo/search.rs
@@ -59,7 +59,7 @@ pub fn search_main(matches: &ArgMatches, icon_paths: &IconPaths) -> i32 {
   result_map.insert("selected", result);
 
   let output = serde_json::to_string(&result_map).expect("unable to encode values as JSON");
-  println!("{}", output);
+  println!("{output}");
 
   0
 }

--- a/espanso/src/cli/modulo/troubleshoot.rs
+++ b/espanso/src/cli/modulo/troubleshoot.rs
@@ -34,7 +34,7 @@ pub fn troubleshoot_main(paths: &Paths, icon_paths: &IconPaths) -> i32 {
 
   let open_file_handler = Box::new(move |file_path: &Path| {
     if let Err(err) = opener::open(file_path) {
-      eprintln!("error opening file: {}", err);
+      eprintln!("error opening file: {err}");
     }
   });
 
@@ -67,7 +67,7 @@ pub fn troubleshoot_main(paths: &Paths, icon_paths: &IconPaths) -> i32 {
         (false, error_sets)
       }
       Err(err) => {
-        let message = format!("{:?}", err);
+        let message = format!("{err:?}");
         let file_path = if message.contains("default.yml") {
           let default_file_path = paths.config.join("config").join("default.yml");
           Some(default_file_path)
@@ -81,7 +81,7 @@ pub fn troubleshoot_main(paths: &Paths, icon_paths: &IconPaths) -> i32 {
             file: file_path,
             errors: vec![espanso_modulo::troubleshooting::ErrorRecord {
               level: espanso_modulo::troubleshooting::ErrorLevel::Error,
-              message: format!("{:?}", err),
+              message: format!("{err:?}"),
             }],
           }],
         )

--- a/espanso/src/cli/service/macos.rs
+++ b/espanso/src/cli/service/macos.rs
@@ -72,7 +72,7 @@ pub fn register() -> Result<()> {
     // Copy the user PATH variable and inject it in the Plist file so that
     // it gets loaded by Launchd.
     // To see why this is necessary: https://github.com/federico-terzi/espanso/issues/233
-    let user_path = std::env::var("PATH").unwrap_or_else(|_| "".to_owned());
+    let user_path = std::env::var("PATH").unwrap_or_else(|_| String::new());
     let plist_content = plist_content.replace("{{{PATH}}}", &user_path);
 
     std::fs::write(plist_file.clone(), plist_content).expect("Unable to write plist file");

--- a/espanso/src/cli/service/mod.rs
+++ b/espanso/src/cli/service/mod.rs
@@ -76,16 +76,14 @@ fn service_main(args: CliModuleArgs) -> i32 {
     if let Err(err) = register() {
       error_eprintln!("unable to register service: {}", err);
       return SERVICE_FAILURE;
-    } else {
-      info_println!("service registered correctly!");
     }
+    info_println!("service registered correctly!");
   } else if cli_args.subcommand_matches("unregister").is_some() {
     if let Err(err) = unregister() {
       error_eprintln!("unable to unregister service: {}", err);
       return SERVICE_FAILURE;
-    } else {
-      info_println!("service unregistered correctly!");
     }
+    info_println!("service unregistered correctly!");
   } else if cli_args.subcommand_matches("check").is_some() {
     if is_registered() {
       info_println!("registered as a service");

--- a/espanso/src/cli/service/win.rs
+++ b/espanso/src/cli/service/win.rs
@@ -97,7 +97,7 @@ pub fn start_service() -> Result<()> {
 
   Command::new(current_path)
     .args(["launcher"])
-    .creation_flags(0x08000008) // CREATE_NO_WINDOW + DETACHED_PROCESS
+    .creation_flags(0x0800_0008) // CREATE_NO_WINDOW + DETACHED_PROCESS
     .spawn()?;
 
   Ok(())

--- a/espanso/src/cli/worker/engine/caches/app_info_provider.rs
+++ b/espanso/src/cli/worker/engine/caches/app_info_provider.rs
@@ -28,7 +28,7 @@ pub struct CachedAppInfoProvider<'a> {
   app_info_provider: &'a dyn AppInfoProvider,
   caching_interval: Duration,
 
-  _cached_info: RefCell<Option<(Instant, AppInfo)>>,
+  cached_info: RefCell<Option<(Instant, AppInfo)>>,
 }
 
 impl<'a> CachedAppInfoProvider<'a> {
@@ -36,14 +36,14 @@ impl<'a> CachedAppInfoProvider<'a> {
     Self {
       app_info_provider,
       caching_interval,
-      _cached_info: RefCell::new(None),
+      cached_info: RefCell::new(None),
     }
   }
 }
 
 impl<'a> AppInfoProvider for CachedAppInfoProvider<'a> {
   fn get_info(&self) -> espanso_info::AppInfo {
-    let mut cached_info = self._cached_info.borrow_mut();
+    let mut cached_info = self.cached_info.borrow_mut();
     if let Some((instant, cached_value)) = &*cached_info {
       if instant.elapsed() < self.caching_interval {
         // Return cached config

--- a/espanso/src/cli/worker/engine/dispatch/executor/event_injector.rs
+++ b/espanso/src/cli/worker/engine/dispatch/executor/event_injector.rs
@@ -76,7 +76,7 @@ impl<'a> TextInjector for EventInjectorAdapter<'a> {
       if i > 0 {
         self
           .injector
-          .send_keys(&[espanso_inject::keys::Key::Enter], injection_options)?
+          .send_keys(&[espanso_inject::keys::Key::Enter], injection_options)?;
       }
 
       self.injector.send_string(line, injection_options)?;

--- a/espanso/src/cli/worker/engine/funnel/key_state.rs
+++ b/espanso/src/cli/worker/engine/funnel/key_state.rs
@@ -110,7 +110,7 @@ impl KeyStatus {
   }
 
   fn release(&mut self) {
-    self.pressed_at = None
+    self.pressed_at = None;
   }
 
   fn press(&mut self) {

--- a/espanso/src/cli/worker/engine/funnel/mod.rs
+++ b/espanso/src/cli/worker/engine/funnel/mod.rs
@@ -66,7 +66,7 @@ pub fn init_and_spawn(
   let key_state_store_clone = key_state_store.clone();
   if let Err(error) = std::thread::Builder::new()
     .name("detect thread".to_string())
-    .spawn(move || match espanso_detect::get_source(source_options) {
+    .spawn(move || match espanso_detect::get_source(&source_options) {
       Ok(mut source) => {
         if source.initialize().is_err() {
           init_tx

--- a/espanso/src/cli/worker/engine/funnel/mod.rs
+++ b/espanso/src/cli/worker/engine/funnel/mod.rs
@@ -66,7 +66,7 @@ pub fn init_and_spawn(
   let key_state_store_clone = key_state_store.clone();
   if let Err(error) = std::thread::Builder::new()
     .name("detect thread".to_string())
-    .spawn(move || match espanso_detect::get_source(&source_options) {
+    .spawn(move || match espanso_detect::get_source(source_options) {
       Ok(mut source) => {
         if source.initialize().is_err() {
           init_tx

--- a/espanso/src/cli/worker/engine/funnel/modifier.rs
+++ b/espanso/src/cli/worker/engine/funnel/modifier.rs
@@ -136,7 +136,7 @@ impl ModifierStatus {
   }
 
   fn release(&mut self) {
-    self.pressed_at = None
+    self.pressed_at = None;
   }
 
   fn press(&mut self) {

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -172,7 +172,7 @@ pub fn initialize_and_spawn(
       let selector = MatchSelectorAdapter::new(&modulo_search_ui, &combined_match_cache);
       let multiplexer = MultiplexAdapter::new(&combined_match_cache, &*context);
 
-      let injector = espanso_inject::get_injector(InjectorCreationOptions {
+      let injector = espanso_inject::get_injector(&InjectorCreationOptions {
         use_evdev: use_evdev_backend,
         keyboard_state_provider: key_state_store
           .map(|store| Box::new(store) as Box<dyn KeyboardStateProvider>),

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -282,7 +282,7 @@ pub fn initialize_and_spawn(
           notification_manager.notify_config_reloaded(true);
         }
         Some(flag) if flag == WORKER_START_REASON_KEYBOARD_LAYOUT_CHANGED => {
-          notification_manager.notify_keyboard_layout_reloaded()
+          notification_manager.notify_keyboard_layout_reloaded();
         }
         _ => {
           notification_manager.notify_start();

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -172,7 +172,7 @@ pub fn initialize_and_spawn(
       let selector = MatchSelectorAdapter::new(&modulo_search_ui, &combined_match_cache);
       let multiplexer = MultiplexAdapter::new(&combined_match_cache, &*context);
 
-      let injector = espanso_inject::get_injector(&InjectorCreationOptions {
+      let injector = espanso_inject::get_injector(InjectorCreationOptions {
         use_evdev: use_evdev_backend,
         keyboard_state_provider: key_state_store
           .map(|store| Box::new(store) as Box<dyn KeyboardStateProvider>),

--- a/espanso/src/cli/worker/engine/process/middleware/matcher/convert.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/matcher/convert.rs
@@ -60,7 +60,7 @@ impl<'a> MatchConverter<'a> {
     // First convert configuration (user-defined) matches
     for m in match_set.matches {
       if let MatchCause::Trigger(cause) = &m.cause {
-        for trigger in cause.triggers.iter() {
+        for trigger in &cause.triggers {
           matches.push(RollingMatch::from_string(
             m.id,
             trigger,
@@ -76,7 +76,7 @@ impl<'a> MatchConverter<'a> {
 
     // Then convert built-in ones
     for m in self.builtin_matches {
-      for trigger in m.triggers.iter() {
+      for trigger in &m.triggers {
         matches.push(RollingMatch::from_string(
           m.id,
           trigger,

--- a/espanso/src/cli/worker/engine/process/middleware/matcher/convert.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/matcher/convert.rs
@@ -69,7 +69,7 @@ impl<'a> MatchConverter<'a> {
               left_word: cause.left_word,
               right_word: cause.right_word,
             },
-          ))
+          ));
         }
       }
     }
@@ -81,7 +81,7 @@ impl<'a> MatchConverter<'a> {
           m.id,
           trigger,
           &StringMatchOptions::default(),
-        ))
+        ));
       }
     }
 
@@ -95,7 +95,7 @@ impl<'a> MatchConverter<'a> {
 
     for m in match_set.matches {
       if let MatchCause::Regex(cause) = &m.cause {
-        matches.push(RegexMatch::new(m.id, &cause.regex))
+        matches.push(RegexMatch::new(m.id, &cause.regex));
       }
     }
 

--- a/espanso/src/cli/worker/engine/process/middleware/matcher/regex.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/matcher/regex.rs
@@ -34,7 +34,7 @@ impl RegexMatcherAdapter {
   pub fn new(matches: &[RegexMatch<i32>], options: &RegexMatcherAdapterOptions) -> Self {
     let matcher = RegexMatcher::new(
       matches,
-      &RegexMatcherOptions {
+      RegexMatcherOptions {
         max_buffer_size: options.max_buffer_size,
       },
     );

--- a/espanso/src/cli/worker/engine/process/middleware/matcher/regex.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/matcher/regex.rs
@@ -34,7 +34,7 @@ impl RegexMatcherAdapter {
   pub fn new(matches: &[RegexMatch<i32>], options: &RegexMatcherAdapterOptions) -> Self {
     let matcher = RegexMatcher::new(
       matches,
-      RegexMatcherOptions {
+      &RegexMatcherOptions {
         max_buffer_size: options.max_buffer_size,
       },
     );

--- a/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
@@ -119,10 +119,10 @@ fn extract_values(value: &Value, trim_string_values: Option<&Value>) -> Option<V
         .filter_map(|line| {
           if trim_string_values {
             let trimmed_line = line.trim();
-            if !trimmed_line.is_empty() {
-              Some(trimmed_line)
-            } else {
+            if trimmed_line.is_empty() {
               None
+            } else {
+              Some(trimmed_line)
             }
           } else {
             Some(line)

--- a/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
@@ -85,7 +85,7 @@ fn generate_global_vars_map(config_provider: &dyn ConfigProvider) -> HashMap<i32
   let mut global_vars_map = HashMap::new();
 
   for (_, match_set) in config_provider.configs() {
-    for var in match_set.global_vars.iter() {
+    for var in &match_set.global_vars {
       global_vars_map
         .entry(var.id)
         .or_insert_with(|| convert_var((*var).clone()));
@@ -104,13 +104,13 @@ fn generate_context<'a>(
   let mut templates = Vec::new();
   let mut global_vars = Vec::new();
 
-  for m in match_set.matches.iter() {
+  for m in &match_set.matches {
     if let Some(Some(template)) = template_map.get(&m.id) {
       templates.push(template);
     }
   }
 
-  for var in match_set.global_vars.iter() {
+  for var in &match_set.global_vars {
     if let Some(var) = global_vars_map.get(&var.id) {
       global_vars.push(var);
     }

--- a/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
@@ -216,7 +216,9 @@ impl<'a> Renderer<'a> for RendererAdapter<'a> {
       };
 
       // If some trigger vars are specified, augment the template with them
-      let augmented_template = if !trigger_vars.is_empty() {
+      let augmented_template = if trigger_vars.is_empty() {
+        None
+      } else {
         let mut augmented = template.clone();
         for (name, value) in trigger_vars {
           let mut params = espanso_render::Params::new();
@@ -233,8 +235,6 @@ impl<'a> Renderer<'a> for RendererAdapter<'a> {
           );
         }
         Some(augmented)
-      } else {
-        None
       };
 
       let template = if let Some(augmented) = augmented_template.as_ref() {

--- a/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
@@ -230,7 +230,7 @@ impl<'a> Renderer<'a> for RendererAdapter<'a> {
               inject_vars: false,
               ..Default::default()
             },
-          )
+          );
         }
         Some(augmented)
       } else {

--- a/espanso/src/cli/worker/ui/notification.rs
+++ b/espanso/src/cli/worker/ui/notification.rs
@@ -63,9 +63,9 @@ impl<'a> espanso_engine::process::NotificationManager for NotificationManager<'a
     }
 
     if enabled {
-      self.notify("Espanso enabled!")
+      self.notify("Espanso enabled!");
     } else {
-      self.notify("Espanso disabled!")
+      self.notify("Espanso disabled!");
     }
   }
 

--- a/espanso/src/gui/modulo/manager.rs
+++ b/espanso/src/gui/modulo/manager.rs
@@ -112,10 +112,10 @@ impl ModuloManager {
                       );
                     }
 
-                    if !output.trim().is_empty() {
-                      Ok(output.to_string())
-                    } else {
+                    if output.trim().is_empty() {
                       Err(ModuloError::EmptyOutput.into())
+                    } else {
+                      Ok(output.to_string())
                     }
                   }
                   Err(error) => Err(ModuloError::Error(error).into()),

--- a/espanso/src/gui/modulo/manager.rs
+++ b/espanso/src/gui/modulo/manager.rs
@@ -109,7 +109,7 @@ impl ModuloManager {
                       error!(
                         "modulo exited with non-zero status code: {:?}",
                         child_output.status.code()
-                      )
+                      );
                     }
 
                     if !output.trim().is_empty() {

--- a/espanso/src/gui/modulo/search.rs
+++ b/espanso/src/gui/modulo/search.rs
@@ -111,7 +111,7 @@ fn convert_items(items: &[SearchItem]) -> Vec<ModuloSearchItemConfig> {
         item
           .additional_search_terms
           .iter()
-          .map(|term| term.as_str())
+          .map(String::as_str)
           .collect()
       },
       is_builtin: item.is_builtin,

--- a/espanso/src/ipc.rs
+++ b/espanso/src/ipc.rs
@@ -54,10 +54,10 @@ pub fn create_ipc_client_to_worker(runtime_dir: &Path) -> Result<impl IPCClient<
 }
 
 fn create_ipc_server(runtime_dir: &Path, name: &str) -> Result<impl IPCServer<IPCEvent>> {
-  espanso_ipc::server(&format!("espanso{}", name), runtime_dir)
+  espanso_ipc::server(&format!("espanso{name}"), runtime_dir)
 }
 
 fn create_ipc_client(runtime_dir: &Path, target_process: &str) -> Result<impl IPCClient<IPCEvent>> {
-  let client = espanso_ipc::client(&format!("espanso{}", target_process), runtime_dir)?;
+  let client = espanso_ipc::client(&format!("espanso{target_process}"), runtime_dir)?;
   Ok(client)
 }

--- a/espanso/src/lock.rs
+++ b/espanso/src/lock.rs
@@ -36,7 +36,7 @@ impl Lock {
   }
 
   fn acquire(runtime_dir: &Path, name: &str) -> Option<Lock> {
-    let lock_file_path = runtime_dir.join(format!("{}.lock", name));
+    let lock_file_path = runtime_dir.join(format!("{name}.lock"));
     let lock_file = OpenOptions::new()
       .read(true)
       .write(true)

--- a/espanso/src/preferences/default.rs
+++ b/espanso/src/preferences/default.rs
@@ -51,7 +51,7 @@ impl<KVSType: KVS> DefaultPreferences<KVSType> {
     self
       .kvs
       .set(key, value)
-      .unwrap_or_else(|_| panic!("unable to write preference for key {}", key))
+      .unwrap_or_else(|_| panic!("unable to write preference for key {}", key));
   }
 }
 

--- a/espanso/src/util.rs
+++ b/espanso/src/util.rs
@@ -26,7 +26,7 @@ pub fn set_command_flags(command: &mut Command) {
   use std::os::windows::process::CommandExt;
   // Avoid showing the shell window
   // See: https://github.com/federico-terzi/espanso/issues/249
-  command.creation_flags(0x08000000);
+  command.creation_flags(0x0800_0000);
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -38,7 +38,7 @@ pub fn set_command_flags(_: &mut Command) {
 pub fn attach_console() {
   // When using the windows subsystem we loose the terminal output.
   // Therefore we try to attach to the current console if available.
-  unsafe { winapi::um::wincon::AttachConsole(0xFFFFFFFF) };
+  unsafe { winapi::um::wincon::AttachConsole(0xFFFF_FFFF) };
 }
 
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Hi! I love clippy lints, and `cargo clippy -- -W clippy::pedantic` gives us a lot of output.
Not everything is useful, but there are some nice things here and there.

the running command I am using

```console
cargo clippy -- -W clippy::pedantic -A clippy::too_many_lines -A clippy::needless_pass_by_value -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::cast_possible_wrap -A clippy::module_name_repetitions -A clippy::match_same_arms -A clippy::unnecessary_wraps -A clippy::cast_possible_truncation -A clippy::must_use_candidate -A clippy::similar_names -A clippy::struct_excessive_bools
```