### PR TITLE
feat(clipboard): add representation for type NSHTMLPboardType in NSPasteboard 

### DIFF
--- a/espanso-clipboard/src/cocoa/native.mm
+++ b/espanso-clipboard/src/cocoa/native.mm
@@ -79,7 +79,8 @@ int32_t clipboard_set_html(char * html, char * fallback_text) {
                                   documentAttributes:nil];
 
   [pasteboard setData:rtf forType:NSRTFPboardType];
-
+  [pasteboard setString:nsHtml forType:NSHTMLPboardType];
+  
   if (fallback_text) {
     NSString *nsText = [NSString stringWithUTF8String:fallback_text];
     [pasteboard setString:nsText forType:NSPasteboardTypeString];


### PR DESCRIPTION
As mentioned in the discussion #1760 by @devcrafting, it looks like that any HTML div tag with the attribute `contenteditable` in webkit-based browsers on MacOs is not able to "consume" RTF text which leads to the fact that raw text is used instead.

A solution which seems to fix the issue is to add a third representation of the data to be pasted for the type NSHTMLPboardType (representation consumables by the browsers in the case specified above).

We have tested it on the latest MacOS version Sonoma (Intel and M2 processor) ensuring that RTF text is still used for applications like TextEdit.