### PR TITLE
fix: :building_construction: fix cargo-make release builds

### DIFF
--- a/.github/scripts/ubuntu/build_appimage.sh
+++ b/.github/scripts/ubuntu/build_appimage.sh
@@ -4,10 +4,10 @@ set -e
 
 echo "Testing espanso..."
 cd espanso
-cargo make test-binary --profile release
+cargo make --profile release -- test-binary
 
 echo "Building espanso and creating AppImage"
-cargo make create-app-image --profile release
+cargo make --profile release -- create-app-image
 
 cd ..
 cp espanso/target/linux/AppImage/out/Espanso-*.AppImage Espanso-X11.AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install cargo-make --version 0.37.5
       - name: Build
-        run: cargo make --env NO_X11=true build-binary
+        run: cargo make --env NO_X11=true -- build-binary
       - name: Check clippy
         run: |
           rustup component add clippy
@@ -128,7 +128,7 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install cargo-make --version 0.37.5
       - name: Run test suite
-        run: cargo make --env NO_X11=true test-binary
+        run: cargo make --env NO_X11=true -- test-binary
   
   build-macos-arm:
     runs-on: macos-11

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -45,13 +45,13 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install --force cargo-make --version 0.37.5
       - name: Test
-        run: cargo make test-binary --profile release
+        run: cargo make --profile release -- test-binary
       - name: Build resources
-        run: cargo make build-windows-resources --profile release
+        run: cargo make --profile release -- build-windows-resources
       - name: Build installer
-        run: cargo make build-windows-installer --profile release --skip-tasks build-windows-resources
+        run: cargo make --profile release --skip-tasks build-windows-resources -- build-windows-installer
       - name: Build portable mode archive 
-        run: cargo make build-windows-portable --profile release --skip-tasks build-windows-resources
+        run: cargo make --profile release --skip-tasks build-windows-resources -- build-windows-portable
       - name: Create portable mode archive
         shell: powershell
         run: |
@@ -133,11 +133,11 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install --force cargo-make --version 0.37.5
       - name: Test
-        run: cargo make test-binary --profile release
+        run: cargo make --profile release -- test-binary
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
       - name: Build
-        run: cargo make create-bundle --profile release
+        run: cargo make --profile release -- create-bundle
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
       - name: Create ZIP archive
@@ -170,7 +170,7 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install --force cargo-make --version 0.37.5
       - name: Build
-        run: cargo make --env BUILD_ARCH=aarch64-apple-darwin create-bundle --profile release 
+        run: cargo make --env BUILD_ARCH=aarch64-apple-darwin --profile release -- create-bundle
       - name: Create ZIP archive
         run: |
           ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-M1.zip

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -65,9 +65,9 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install --force cargo-make --version 0.37.5
       - name: Test
-        run: cargo make test-binary --profile release
+        run: cargo make --profile release -- test-binary
       - name: Build resources
-        run: cargo make build-windows-resources --profile release
+        run: cargo make --profile release -- build-windows-resources
       - name: Sign resources
         run: cargo make sign-windows-resources
         env:
@@ -75,7 +75,7 @@ jobs:
           CODESIGN_CROSS_SIGNED_B64: ${{ secrets.WIN_CODESIGN_INTERMEDIATE_B64 }}
           CODESIGN_CERTIFICATE_B64: ${{ secrets.WIN_CODESIGN_CERTIFICATE_B64 }}
       - name: Build installer
-        run: cargo make build-windows-installer --profile release --skip-tasks build-windows-resources
+        run: cargo make --profile release --skip-tasks build-windows-resources -- build-windows-installer
       - name: Sign installer
         run: cargo make sign-windows-installer
         env:
@@ -83,7 +83,7 @@ jobs:
           CODESIGN_CROSS_SIGNED_B64: ${{ secrets.WIN_CODESIGN_INTERMEDIATE_B64 }}
           CODESIGN_CERTIFICATE_B64: ${{ secrets.WIN_CODESIGN_CERTIFICATE_B64 }}
       - name: Build portable mode archive 
-        run: cargo make build-windows-portable --profile release --skip-tasks build-windows-resources
+        run: cargo make --profile release --skip-tasks build-windows-resources -- build-windows-portable
       - name: Create portable mode archive
         shell: powershell
         run: |
@@ -180,11 +180,11 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install --force cargo-make --version 0.37.5
       - name: Test
-        run: cargo make test-binary --profile release
+        run: cargo make --profile release -- test-binary
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
       - name: Build
-        run: cargo make create-bundle --profile release
+        run: cargo make --profile release -- create-bundle
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
       - name: Codesign executable
@@ -253,7 +253,7 @@ jobs:
           cargo install rust-script --version "0.7.0"
           cargo install --force cargo-make --version 0.37.5
       - name: Build
-        run: cargo make --env BUILD_ARCH=aarch64-apple-darwin create-bundle --profile release 
+        run: cargo make --env BUILD_ARCH=aarch64-apple-darwin --profile release -- create-bundle
       - name: Codesign executable
         env: 
           MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}

--- a/Compilation.md
+++ b/Compilation.md
@@ -2,11 +2,11 @@
 
 This document tries to explain the various steps needed to build espanso. (Work in progress).
 
-# Prerequisites
+## Prerequisites
 
 These are the basic tools required to build espanso:
 
-* A recent Rust compiler. You can install it following these instructions: https://www.rust-lang.org/tools/install
+* A recent Rust compiler. You can install it following [these instructions](https://www.rust-lang.org/tools/install)
 * A C/C++ compiler. There are multiple of them depending on the platform, but espanso officially supports the following:
   * On Windows, you should use the MSVC compiler. The easiest way to install it is by downloading [Visual Studio](https://visualstudio.microsoft.com/) and checking "Desktop development with C++" in the installer.
   Note that [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) alone doesn't fulfill all the requirements for espanso.
@@ -16,107 +16,110 @@ These are the basic tools required to build espanso:
 * Espanso heavily relies on [cargo make](https://github.com/sagiegurari/cargo-make) for the various packaging
 steps. You can install it by running:
 
-```
+```bash
 cargo install rust-script --version "0.7.0"
 cargo install --force cargo-make --version 0.37.5
 ```
 
-# Windows
+## Windows
 
 After installing the prerequisites, you are ready to compile Espanso on Windows.
 
 Espanso supports multiple targets on Windows: plain executable, installer and portable mode. The following sections explain how to build Espanso for these configurations.
 
-## Plain executable
+### Plain executable
 
 If you only want to build the "plain" Espanso executable, you can do so by running:
 
-```
-cargo make build-binary --profile release
+```bash
+cargo make --profile release -- build-binary
 ```
 
 This will create an `espanso` executable in the `target/release` directory.
 
-## Installer
+### Installer
 
 If you want to build the Installer (the executable that installs Espanso on a machine), you can run:
 
-```
-cargo make build-windows-installer --profile release
+```bash
+cargo make --profile release -- build-windows-installer
 ```
 
 This will generate the installer in the `target/windows/installer` directory.
 
-## Portable mode bundle
+### Portable mode bundle
 
 You can also generate a portable-mode bundle (a self-contained ZIP archive that does not require installation) by running:
 
+```bash
+cargo make --profile release -- build-windows-portable
 ```
-cargo make build-windows-portable --profile release
-```
+
 This will generate the executable in the `target/windows/portable` directory.
 There are README instructions inside!.
 
-# MacOS
+## MacOS
 
 After installing the prerequisites, you are ready to build Espanso on macOS.
 
 Espanso supports two targets on macOS: plain executable and App Bundle. For most cases, the App Bundle format is preferrable.
 
-## App Bundle
+### App Bundle
 
 You can build the App Bundle by running:
 
-```
-cargo make create-bundle --profile release
+```bash
+cargo make --profile release -- create-bundle
 ```
 
 This will create the `Espanso.app` bundle in the `target/mac` directory.
 
-# Linux
+## Linux
 
 Espanso on Linux comes in two different flavors: one for X11 and one for Wayland.
-If you don't know which one to choose, follow these steps to determine which one you are running: https://unix.stackexchange.com/a/325972
+If you don't know which one to choose, follow [these steps to determine which one you are running](https://unix.stackexchange.com/a/325972).
 
-## Compiling for X11
-
-### Necessary packages
+### Necessary dependencies
 
 If compiling on a version of Ubuntu X11 before 22.04 (including 22.04):
+
 * `sudo apt install libx11-dev libxtst-dev libxkbcommon-dev libdbus-1-dev libwxgtk3.0-gtk3-dev`
 
 If compiling on a version of Ubuntu X11 after 22.04:
+
 * `sudo apt install libx11-dev libxtst-dev libxkbcommon-dev libdbus-1-dev libwxgtk3.2-dev`
 
-### AppImage
+### Compiling for X11
+
+#### X11 AppImage
 
 The AppImage is a convenient format to distribute Linux applications, as besides the binary,
 it also bundles all the required libraries.
 
 You can create the AppImage by running (this will work on X11 systems):
 
-```
-cargo make create-app-image --profile release
+```bash
+cargo make --profile release -- create-app-image
 ```
 
 You will find the resulting AppImage in the `target/linux/AppImage/out` folder.
 
-### Binary
+#### Binary
 
 You can build the Espanso binary on X11 by running the following command:
 
-```
-cargo make build-binary --profile release
+```bash
+cargo make --profile release -- build-binary
 ```
 
 You'll then find the `espanso` binary in the `target/release` directory.
 
-## Compiling on Wayland
+### Compiling on Wayland
 
 You can build Espanso on Wayland by running:
 
-```
-cargo make build-binary --env NO_X11=true --profile release
+```bash
+cargo make --env NO_X11=true --profile release -- build-binary
 ```
 
 You'll then find the `espanso` binary in the `target/release` directory.

--- a/scripts/build_binary.rs
+++ b/scripts/build_binary.rs
@@ -23,16 +23,14 @@ fn main() {
   let wayland = envmnt::get_or("NO_X11", "false") == "true";
   if wayland {
     println!("Using Wayland feature");
-  }
-  else {
+  } else {
     println!("Using X11 default feature");
   }
 
   let avoid_modulo = envmnt::get_or("NO_MODULO", "false") == "true";
   if avoid_modulo {
     println!("Skipping modulo feature");
-  }
-  else {
+  } else {
     println!("Building with default modulo");
   }
 


### PR DESCRIPTION
I was trying to debug an issue and found out that:
```bash
cargo make build-binary --env NO_X11=true --profile release
```

builds the debug version instead of the release, with this output

```
$ cargo make build-binary --env NO_X11=true RELEASE=true
[cargo-make] INFO - cargo make 0.37.5
[cargo-make] INFO - Calling cargo metadata to extract project info
[cargo-make] INFO - Cargo metadata done
[cargo-make] INFO - Calling cargo metadata to extract project info
[cargo-make] INFO - Cargo metadata done
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: build-binary
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: legacy-migration
[cargo-make] INFO - Running Task: build-binary
[cargo-make] INFO - Execute Command: "rust-script" "/home/acoyan/other-repos/espanso/espanso/target/_cargo_make_temp/persisted_scripts/569357E6CEA1F7732052A6A426E226A74FBF1B27BDF1C65A4B4DB88FBFEEAED4.rs" "--env" "NO_X11=true" "RELEASE=true"
Using profile: Debug
Using X11 default feature
Building with default modulo
```
Reading the cargo-make help
```
cargo-make 0.37.5
Sagie Gur-Ari <sagiegurari@gmail.com>
Rust task runner and build tool.

USAGE:
    [makers | cargo make | cargo-make make] [OPTIONS] [--] [<TASK_CMD>...]

```
The problem lies in the `cargo-make` command, that it should be
```
cargo make --env NO_X11=true --profile release -- build-binary
```

I fixed this and other builds. And also some minor lints in the `Compilation.md` document