### PR TITLE
Revert PR 1769 (fixes #1826)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,15 +178,12 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.10.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eb0438b3c6d262395fe30e6de9a61beb57ea56290b00a07f227fe6e20cbf2"
+checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
 dependencies = [
  "log",
- "nix",
- "slotmap",
- "thiserror",
- "vec_map",
+ "nix 0.22.3",
 ]
 
 [[package]]
@@ -1600,9 +1597,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
 dependencies = [
  "libc",
 ]
@@ -1763,6 +1760,19 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags 1.2.1",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nix"
@@ -2638,15 +2648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
-name = "slotmap"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,9 +2655,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
+checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
 dependencies = [
  "bitflags 1.2.1",
  "calloop",
@@ -2664,7 +2665,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix",
+ "nix 0.22.3",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
@@ -3277,7 +3278,7 @@ dependencies = [
  "bitflags 1.2.1",
  "downcast-rs",
  "libc",
- "nix",
+ "nix 0.24.2",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -3290,7 +3291,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
- "nix",
+ "nix 0.24.2",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -3302,7 +3303,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
- "nix",
+ "nix 0.24.2",
  "wayland-client",
  "xcursor",
 ]

--- a/espanso-detect/Cargo.toml
+++ b/espanso-detect/Cargo.toml
@@ -24,7 +24,7 @@ widestring = "0.4.3"
 [target.'cfg(target_os="linux")'.dependencies]
 libc = "0.2.85"
 scopeguard = "1.1.0"
-sctk = { package = "smithay-client-toolkit", version = "0.16.1", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.15.4", optional = true }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/espanso/Cargo.toml
+++ b/espanso/Cargo.toml
@@ -98,7 +98,7 @@ section = "utility"
 license-file = ["../LICENSE", "1"]
 
 [package.metadata.deb.variants.wayland]
-depends = "libc6 (>= 2.27), libdbus-1-3 (>= 1.9.14), libgcc1 (>= 1:4.2), libnotify-bin, libstdc++6 (>= 5), libwxgtk3.0-gtk3-0v5 (>= 3.0.4+dfsg) | libwxgtk3.2-1, libxkbcommon0 (>= 0.5.0), systemd, wl-clipboard"
+depends = "$auto"
 # TODO: once this issue [1] is fixed, we should create a variant for
 # wayland to automatically run the setcap script.
 # [1]: https://github.com/mmstick/cargo-deb/issues/151

--- a/espanso/src/cli/log.rs
+++ b/espanso/src/cli/log.rs
@@ -43,7 +43,7 @@ fn log_main(args: CliModuleArgs) -> i32 {
   let log_file = File::open(log_file);
   if let Ok(log_file) = log_file {
     let reader = BufReader::new(log_file);
-    for line in reader.lines().flatten() {
+    for line in reader.lines().map_while(Result::ok) {
       println!("{line}");
     }
   } else {


### PR DESCRIPTION
I've been `git bisect`ing and found 2 problems, 
one, the build of the dpkg with the old ubuntu distro (18.04) is messing with modern debian distributions. It installs with gtk3.0 but it has been deprecated in debian 12 (and ubuntu 22.04 I believe). I solved this by writing a manual script to compile a `.deb` file and running manually the script in every bisect.

```bash
#!/bin/bash
set -e
echo "Installing cargo-deb"
cargo install cargo-deb --version 1.44.1

echo "Building Wayland deb package"
cargo deb -p espanso --variant wayland -- --no-default-features --features "modulo wayland vendored-tls"

cp target/debian/espanso-wayland*.deb espanso-debian-wayland-amd64.deb
echo "  Done!"
```
This works allright, except the dependencies written in `espanso/Cargo.toml` aren't quite right, causing installation failures (#1793, #1739, #1662 )
So this led me to write 
```toml
depends = "$auto"
```
on the wayland

These PRs #1697 #1769 are rolled back in this proposal. The problem with the second is that is pointed to Hyperland, a minor desktop enviroment, while Wayland is broken in many PCs. (#1826 )

I don't know how to provide another solution to the issues #1768 and #1750. Maybe updating client-toolkit to their latest version, v0.18.1, we'll see..

this fixes #1793 

## Instructions to try this PR:
checkout the git branch:
```bash
git clone -b revert-PR-1769 https://github.com/AucaCoyan/espanso
cd espanso/
```
install the dependencies:
```bash
cargo install rust-script --version "0.7.0"
cargo install --force cargo-make --version 0.37.5
sudo apt install libx11-dev libxtst-dev libxkbcommon-dev libdbus-1-dev libwxgtk3.2-dev
```
and then compile the `.dpkg`
```bash
#!/bin/bash
set -e
echo "Installing cargo-deb"
cargo install cargo-deb --version 1.44.1

echo "Building Wayland deb package"
cargo deb -p espanso --variant wayland -- --no-default-features --features "modulo wayland vendored-tls"

cp target/debian/espanso-wayland*.deb espanso-debian-wayland-amd64.deb
echo "  Done!"
```
