### PR TITLE
:construction_worker: make clippy run before the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
         run: |
           cargo install rust-script --version "0.7.0"
           cargo install cargo-make --version 0.37.5
+      - name: Check clippy
+        run: |
+          rustup component add clippy
+          cargo clippy -- -D warnings
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
       # wxWidgets builds (internal to espanso-modulo) are by far the largest bottleneck
       # in the current pipeline, so we cache the results for a faster compilation process
       - name: "Cache wxWidgets builds"
@@ -53,12 +59,6 @@ jobs:
       - name: Build
         run: |
           cargo make build-binary
-      - name: Check clippy
-        run: |
-          rustup component add clippy
-          cargo clippy -- -D warnings
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
 
   test:
     strategy:
@@ -95,6 +95,10 @@ jobs:
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
+      - name: Check clippy
+        run: |
+          rustup component add clippy
+          cargo clippy -p espanso --features wayland -- -D warnings
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -105,10 +109,6 @@ jobs:
           cargo install cargo-make --version 0.37.5
       - name: Build
         run: cargo make --env NO_X11=true -- build-binary
-      - name: Check clippy
-        run: |
-          rustup component add clippy
-          cargo clippy -p espanso --features wayland -- -D warnings
   
   test-wayland:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check
+      - name: Check clippy
+        run: |
+          rustup component add clippy
+          cargo clippy -- -D warnings
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
       - name: Install Linux dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -41,12 +47,6 @@ jobs:
         run: |
           cargo install rust-script --version "0.7.0"
           cargo install cargo-make --version 0.37.5
-      - name: Check clippy
-        run: |
-          rustup component add clippy
-          cargo clippy -- -D warnings
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
       # wxWidgets builds (internal to espanso-modulo) are by far the largest bottleneck
       # in the current pipeline, so we cache the results for a faster compilation process
       - name: "Cache wxWidgets builds"


### PR DESCRIPTION
I noticed that the CI does this things in order:
- checks out the repository
- uses `rust-cache`
- checks the formatting
- installs the linux dependencies
- installs `rust-script` and `cargo-make`
- caches `wxWidgets` builds
- builds the binary
- and then runs clippy

And thought that clippy should be runned just after the formatting, this PR fixes that