### PR TITLE
Use new sctk api

### DIFF
--- a/espanso-detect/Cargo.toml
+++ b/espanso-detect/Cargo.toml
@@ -30,7 +30,7 @@ widestring = "0.4.3"
 [target.'cfg(target_os="linux")'.dependencies]
 libc = "0.2.85"
 scopeguard = "1.1.0"
-sctk = { package = "smithay-client-toolkit", version = "0.16.1", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.18.1", optional = true }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/espanso-detect/src/evdev/sync/wayland.rs
+++ b/espanso-detect/src/evdev/sync/wayland.rs
@@ -1,203 +1,367 @@
-// This module was implemented starting from this wonderful example:
-// https://github.com/Smithay/client-toolkit/blob/master/examples/kbd_input.rs
+// Majority of code below reproduced from https://github.com/Smithay/client-toolkit/blob/master/examples/simple_window.rs
 
-use std::cell::RefCell;
-use std::cmp::min;
-use std::rc::Rc;
+use super::ModifiersState;
+use anyhow::Result;
+use log::debug;
+use std::{convert::TryInto, time::Duration};
 
-use anyhow::{Context, Result};
-use log::error;
-use sctk::reexports::calloop;
-use sctk::reexports::client::protocol::{wl_keyboard, wl_shm, wl_surface};
-use sctk::seat::keyboard::{map_keyboard_repeat, Event as KbEvent, RepeatKind};
-use sctk::shm::AutoMemPool;
-use sctk::window::{Event as WEvent, FallbackFrame};
-
-sctk::default_environment!(EspansoModifiersSync, desktop);
+use sctk::activation::RequestData;
+use sctk::reexports::calloop::EventLoop;
+use sctk::reexports::calloop_wayland_source::WaylandSource;
+use sctk::reexports::client::{
+  globals::registry_queue_init,
+  protocol::{wl_keyboard, wl_output, wl_seat, wl_shm, wl_surface},
+  Connection, QueueHandle,
+};
+use sctk::{
+  activation::{ActivationHandler, ActivationState},
+  compositor::{CompositorHandler, CompositorState},
+  delegate_activation, delegate_compositor, delegate_keyboard, delegate_output, delegate_registry,
+  delegate_seat, delegate_shm, delegate_xdg_shell, delegate_xdg_window,
+  output::{OutputHandler, OutputState},
+  registry::{ProvidesRegistryState, RegistryState},
+  registry_handlers,
+  seat::{
+    keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers},
+    Capability, SeatHandler, SeatState,
+  },
+  shell::{
+    xdg::{
+      window::{Window, WindowConfigure, WindowDecorations, WindowHandler},
+      XdgShell,
+    },
+    WaylandSurface,
+  },
+  shm::{
+    slot::{Buffer, SlotPool},
+    Shm, ShmHandler,
+  },
+};
 
 pub fn get_modifiers_state() -> Result<Option<super::ModifiersState>> {
-  let (env, display, queue) = sctk::new_default_environment!(EspansoModifiersSync, desktop)
-    .context("Unable to connect to a Wayland compositor")?;
+  let conn = Connection::connect_to_env().unwrap();
 
-  let result = Rc::new(RefCell::new(None));
+  // Enumerate the list of globals to get the protocols the server implements.
+  let (globals, event_queue) = registry_queue_init(&conn).unwrap();
 
-  /*
-   * Prepare a calloop event loop to handle key repetion
-   */
-  // Here `Option<WEvent>` is the type of a global value that will be shared by
-  // all callbacks invoked by the event loop.
-  let mut event_loop = calloop::EventLoop::<Option<WEvent>>::try_new().unwrap();
+  let qh = event_queue.handle();
 
-  /*
-   * Create a buffer with window contents
-   */
+  let mut event_loop: EventLoop<SimpleWindow> =
+    EventLoop::try_new().expect("Failed to initialize the event loop!");
 
-  let mut dimensions = (1u32, 1u32);
-
-  /*
-   * Init wayland objects
-   */
-
-  let surface = env.create_surface().detach();
-
-  let mut window = env
-    .create_window::<FallbackFrame, _>(surface, None, dimensions, move |evt, mut dispatch_data| {
-      let next_action = dispatch_data.get::<Option<WEvent>>().unwrap();
-      // Keep last event in priority order : Close > Configure > Refresh
-      let replace = matches!(
-        (&evt, &*next_action),
-        (_, &None | &Some(WEvent::Refresh))
-          | (&WEvent::Configure { .. }, &Some(WEvent::Configure { .. }))
-          | (&WEvent::Close, _)
-      );
-      if replace {
-        *next_action = Some(evt);
-      }
-    })
-    .context("Failed to create a window !")?;
-
-  window.set_title("Espanso Sync Tool".to_string());
-
-  let mut pool = env
-    .create_auto_pool()
-    .context("Failed to create a memory pool !")?;
-
-  /*
-   * Keyboard initialization
-   */
-
-  let mut seats = Vec::<(String, Option<wl_keyboard::WlKeyboard>)>::new();
-
-  // first process already existing seats
-  for seat in env.get_all_seats() {
-    if let Some((has_kbd, name)) = sctk::seat::with_seat_data(&seat, |seat_data| {
-      (
-        seat_data.has_keyboard && !seat_data.defunct,
-        seat_data.name.clone(),
-      )
-    }) {
-      if has_kbd {
-        let result_clone = result.clone();
-        match map_keyboard_repeat(
-          event_loop.handle(),
-          &seat,
-          None,
-          RepeatKind::System,
-          move |event, _, _| keyboard_event_handler(event, &result_clone),
-        ) {
-          Ok(kbd) => {
-            seats.push((name, Some(kbd)));
-          }
-          Err(e) => {
-            error!("Failed to map keyboard on seat {} : {:?}.", name, e);
-            seats.push((name, None));
-          }
-        }
-      } else {
-        seats.push((name, None));
-      }
-    }
-  }
-
-  // then setup a listener for changes
   let loop_handle = event_loop.handle();
-  let result_clone = result.clone();
-  let _seat_listener = env.listen_for_seats(move |seat, seat_data, _| {
-    let result_clone = result_clone.clone();
-    // find the seat in the vec of seats, or insert it if it is unknown
-    let idx = seats.iter().position(|(name, _)| name == &seat_data.name);
-    let idx = idx.unwrap_or_else(|| {
-      seats.push((seat_data.name.clone(), None));
-      seats.len() - 1
-    });
 
-    let (_, ref mut opt_kbd) = &mut seats[idx];
-    // we should map a keyboard if the seat has the capability & is not defunct
-    if seat_data.has_keyboard && !seat_data.defunct {
-      if opt_kbd.is_none() {
-        // we should initalize a keyboard
-        match map_keyboard_repeat(
-          loop_handle.clone(),
-          &seat,
-          None,
-          RepeatKind::System,
-          move |event, _, _| keyboard_event_handler(event, &result_clone),
-        ) {
-          Ok(kbd) => {
-            *opt_kbd = Some(kbd);
-          }
-          Err(e) => {
-            eprintln!(
-              "Failed to map keyboard on seat {} : {:?}.",
-              seat_data.name, e
-            );
-          }
-        }
-      }
-    } else if let Some(kbd) = opt_kbd.take() {
-      // the keyboard has been removed, cleanup
-      kbd.release();
-    }
-  });
-
-  if !env.get_shell().unwrap().needs_configure() {
-    // initial draw to bootstrap on wl_shell
-    redraw(&mut pool, window.surface(), dimensions).expect("Failed to draw");
-    window.refresh();
-  }
-
-  sctk::WaylandSource::new(queue)
-    .quick_insert(event_loop.handle())
+  WaylandSource::new(conn.clone(), event_queue)
+    .insert(loop_handle)
     .unwrap();
 
-  let mut next_action = None;
+  // The compositor (not to be confused with the server which is commonly called the compositor) allows
+  // configuring surfaces to be presented.
+  let compositor = CompositorState::bind(&globals, &qh).expect("wl_compositor not available");
+  // For desktop platforms, the XDG shell is the standard protocol for creating desktop windows.
+  let xdg_shell = XdgShell::bind(&globals, &qh).expect("xdg shell is not available");
+  // Since we are not using the GPU in this example, we use wl_shm to allow software rendering to a buffer
+  // we share with the compositor process.
+  let shm = Shm::bind(&globals, &qh).expect("wl shm is not available.");
+  // If the compositor supports xdg-activation it probably wants us to use it to get focus
+  let xdg_activation = ActivationState::bind(&globals, &qh).ok();
 
-  loop {
-    match next_action.take() {
-      Some(WEvent::Close) => break,
-      Some(WEvent::Refresh) => {
-        window.refresh();
-        window.surface().commit();
-      }
-      Some(WEvent::Configure {
-        new_size,
-        states: _,
-      }) => {
-        if let Some((w, h)) = new_size {
-          window.resize(w, h);
-          dimensions = (w, h);
-        }
-        window.refresh();
-        redraw(&mut pool, window.surface(), dimensions).expect("Failed to draw");
-      }
-      None => {
-        let result_clone = result.clone();
-        let result_ref = result_clone.borrow();
+  // A window is created from a surface.
+  let surface = compositor.create_surface(&qh);
+  // And then we can create the window.
+  let window = xdg_shell.create_window(surface, WindowDecorations::RequestServer, &qh);
+  // Configure the window, this may include hints to the compositor about the desired minimum size of the
+  // window, app id for WM identification, the window title, etc.
+  window.set_title("Espanso Sync Tool");
+  // GitHub does not let projects use the `org.github` domain but the `io.github` domain is fine.
+  window.set_app_id("Espanso.SyncTool");
+  window.set_min_size(Some((256, 256)));
 
-        if let Some(result) = &*result_ref {
-          return Ok(Some(*result));
-        }
-      }
-    }
+  // In order for the window to be mapped, we need to perform an initial commit with no attached buffer.
+  // For more info, see WaylandSurface::commit
+  //
+  // The compositor will respond with an initial configure that we can then use to present to the window with
+  // the correct options.
+  window.commit();
 
-    // always flush the connection before going to sleep waiting for events
-    display.flush().unwrap();
-
-    event_loop
-      .dispatch(Some(std::time::Duration::from_millis(10)), &mut next_action)
-      .unwrap();
+  // To request focus, we first need to request a token
+  if let Some(activation) = xdg_activation.as_ref() {
+    activation.request_token(
+      &qh,
+      RequestData {
+        seat_and_serial: None,
+        surface: Some(window.wl_surface().clone()),
+        app_id: Some(String::from("Espanso.SyncTool")),
+      },
+    )
   }
 
-  Ok(None)
+  // We don't know how large the window will be yet, so lets assume the minimum size we suggested for the
+  // initial memory allocation.
+  let pool = SlotPool::new(256 * 256 * 4, &shm).expect("Failed to create pool");
+
+  let mut simple_window = SimpleWindow {
+    // Seats and outputs may be hotplugged at runtime, therefore we need to setup a registry state to
+    // listen for seats and outputs.
+    registry_state: RegistryState::new(&globals),
+    seat_state: SeatState::new(&globals, &qh),
+    output_state: OutputState::new(&globals, &qh),
+    shm,
+    xdg_activation,
+
+    exit: false,
+    first_configure: true,
+    pool,
+    width: 256,
+    height: 256,
+    shift: None,
+    buffer: None,
+    window,
+    keyboard: None,
+    keyboard_focus: false,
+    modifiers: None,
+  };
+
+  conn.flush().unwrap();
+
+  loop {
+    if simple_window.modifiers.is_some() {
+      debug!("{:?}", simple_window.modifiers);
+      return Ok(simple_window.modifiers);
+    }
+
+    event_loop
+      .dispatch(Duration::from_millis(16), &mut simple_window)
+      .unwrap();
+  }
+  // We don't draw immediately, the configure will notify us when to first draw.
 }
 
-fn keyboard_event_handler(
-  event: KbEvent,
-  result_clone: &Rc<RefCell<Option<super::ModifiersState>>>,
-) {
-  if let KbEvent::Modifiers { modifiers } = event {
-    let mut result_mut = (**result_clone).borrow_mut();
-    *result_mut = Some(super::ModifiersState {
+struct SimpleWindow {
+  registry_state: RegistryState,
+  seat_state: SeatState,
+  output_state: OutputState,
+  shm: Shm,
+  xdg_activation: Option<ActivationState>,
+
+  exit: bool,
+  first_configure: bool,
+  pool: SlotPool,
+  width: u32,
+  height: u32,
+  shift: Option<u32>,
+  buffer: Option<Buffer>,
+  window: Window,
+  keyboard: Option<wl_keyboard::WlKeyboard>,
+  keyboard_focus: bool,
+  modifiers: Option<ModifiersState>,
+}
+
+impl CompositorHandler for SimpleWindow {
+  fn scale_factor_changed(
+    &mut self,
+    _conn: &Connection,
+    _qh: &QueueHandle<Self>,
+    _surface: &wl_surface::WlSurface,
+    _new_factor: i32,
+  ) {
+    // Not needed for this example.
+  }
+
+  fn transform_changed(
+    &mut self,
+    _conn: &Connection,
+    _qh: &QueueHandle<Self>,
+    _surface: &wl_surface::WlSurface,
+    _new_transform: wl_output::Transform,
+  ) {
+    // Not needed for this example.
+  }
+
+  fn frame(
+    &mut self,
+    conn: &Connection,
+    qh: &QueueHandle<Self>,
+    _surface: &wl_surface::WlSurface,
+    _time: u32,
+  ) {
+    self.draw(conn, qh);
+  }
+}
+
+impl OutputHandler for SimpleWindow {
+  fn output_state(&mut self) -> &mut OutputState {
+    &mut self.output_state
+  }
+
+  fn new_output(
+    &mut self,
+    _conn: &Connection,
+    _qh: &QueueHandle<Self>,
+    _output: wl_output::WlOutput,
+  ) {
+  }
+
+  fn update_output(
+    &mut self,
+    _conn: &Connection,
+    _qh: &QueueHandle<Self>,
+    _output: wl_output::WlOutput,
+  ) {
+  }
+
+  fn output_destroyed(
+    &mut self,
+    _conn: &Connection,
+    _qh: &QueueHandle<Self>,
+    _output: wl_output::WlOutput,
+  ) {
+  }
+}
+
+impl WindowHandler for SimpleWindow {
+  fn request_close(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &Window) {
+    self.exit = true;
+  }
+
+  fn configure(
+    &mut self,
+    conn: &Connection,
+    qh: &QueueHandle<Self>,
+    _window: &Window,
+    configure: WindowConfigure,
+    _serial: u32,
+  ) {
+    debug!("Window configured to: {:?}", configure);
+
+    self.buffer = None;
+    self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
+    self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
+
+    // Initiate the first draw.
+    if self.first_configure {
+      self.first_configure = false;
+      self.draw(conn, qh);
+    }
+  }
+}
+
+impl ActivationHandler for SimpleWindow {
+  type RequestData = RequestData;
+
+  fn new_token(&mut self, token: String, _data: &Self::RequestData) {
+    self
+      .xdg_activation
+      .as_ref()
+      .unwrap()
+      .activate::<SimpleWindow>(self.window.wl_surface(), token);
+  }
+}
+
+impl SeatHandler for SimpleWindow {
+  fn seat_state(&mut self) -> &mut SeatState {
+    &mut self.seat_state
+  }
+
+  fn new_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+
+  fn new_capability(
+    &mut self,
+    _conn: &Connection,
+    qh: &QueueHandle<Self>,
+    seat: wl_seat::WlSeat,
+    capability: Capability,
+  ) {
+    if capability == Capability::Keyboard && self.keyboard.is_none() {
+      debug!("Set keyboard capability");
+      let keyboard = self
+        .seat_state
+        .get_keyboard(qh, &seat, None)
+        .expect("Failed to create keyboard");
+
+      self.keyboard = Some(keyboard);
+    }
+  }
+
+  fn remove_capability(
+    &mut self,
+    _conn: &Connection,
+    _: &QueueHandle<Self>,
+    _: wl_seat::WlSeat,
+    capability: Capability,
+  ) {
+    if capability == Capability::Keyboard && self.keyboard.is_some() {
+      debug!("Unset keyboard capability");
+      self.keyboard.take().unwrap().release();
+    }
+  }
+
+  fn remove_seat(&mut self, _: &Connection, _: &QueueHandle<Self>, _: wl_seat::WlSeat) {}
+}
+
+impl KeyboardHandler for SimpleWindow {
+  fn enter(
+    &mut self,
+    _: &Connection,
+    _: &QueueHandle<Self>,
+    _: &wl_keyboard::WlKeyboard,
+    surface: &wl_surface::WlSurface,
+    _: u32,
+    _: &[u32],
+    keysyms: &[Keysym],
+  ) {
+    if self.window.wl_surface() == surface {
+      debug!("Keyboard focus on window with pressed syms: {keysyms:?}");
+      self.keyboard_focus = true;
+    }
+  }
+
+  fn leave(
+    &mut self,
+    _: &Connection,
+    _: &QueueHandle<Self>,
+    _: &wl_keyboard::WlKeyboard,
+    surface: &wl_surface::WlSurface,
+    _: u32,
+  ) {
+    if self.window.wl_surface() == surface {
+      debug!("Release keyboard focus on window");
+      self.keyboard_focus = false;
+    }
+  }
+
+  fn press_key(
+    &mut self,
+    _conn: &Connection,
+    _qh: &QueueHandle<Self>,
+    _: &wl_keyboard::WlKeyboard,
+    _: u32,
+    event: KeyEvent,
+  ) {
+    debug!("Key press: {event:?}");
+  }
+
+  fn release_key(
+    &mut self,
+    _: &Connection,
+    _: &QueueHandle<Self>,
+    _: &wl_keyboard::WlKeyboard,
+    _: u32,
+    event: KeyEvent,
+  ) {
+    debug!("Key release: {event:?}");
+  }
+
+  fn update_modifiers(
+    &mut self,
+    _: &Connection,
+    _: &QueueHandle<Self>,
+    _: &wl_keyboard::WlKeyboard,
+    _serial: u32,
+    modifiers: Modifiers,
+  ) {
+    debug!("Update modifiers: {modifiers:?}");
+    self.modifiers = Some(ModifiersState {
       ctrl: modifiers.ctrl,
       alt: modifiers.alt,
       shift: modifiers.shift,
@@ -208,36 +372,111 @@ fn keyboard_event_handler(
   }
 }
 
-#[allow(clippy::many_single_char_names)]
-fn redraw(
-  pool: &mut AutoMemPool,
-  surface: &wl_surface::WlSurface,
-  (buf_x, buf_y): (u32, u32),
-) -> Result<(), ::std::io::Error> {
-  let (canvas, new_buffer) = pool.buffer(
-    buf_x as i32,
-    buf_y as i32,
-    4 * buf_x as i32,
-    wl_shm::Format::Argb8888,
-  )?;
-  for (i, dst_pixel) in canvas.chunks_exact_mut(4).enumerate() {
-    let x = i as u32 % buf_x;
-    let y = i as u32 / buf_x;
-    let r: u32 = min(((buf_x - x) * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
-    let g: u32 = min((x * 0xFF) / buf_x, ((buf_y - y) * 0xFF) / buf_y);
-    let b: u32 = min(((buf_x - x) * 0xFF) / buf_x, (y * 0xFF) / buf_y);
-    let pixel: [u8; 4] = ((0xFF << 24) + (r << 16) + (g << 8) + b).to_ne_bytes();
-    dst_pixel[0] = pixel[0];
-    dst_pixel[1] = pixel[1];
-    dst_pixel[2] = pixel[2];
-    dst_pixel[3] = pixel[3];
+impl ShmHandler for SimpleWindow {
+  fn shm_state(&mut self) -> &mut Shm {
+    &mut self.shm
   }
-  surface.attach(Some(&new_buffer), 0, 0);
-  if surface.as_ref().version() >= 4 {
-    surface.damage_buffer(0, 0, buf_x as i32, buf_y as i32);
-  } else {
-    surface.damage(0, 0, buf_x as i32, buf_y as i32);
+}
+
+impl SimpleWindow {
+  pub fn draw(&mut self, _conn: &Connection, qh: &QueueHandle<Self>) {
+    let width = self.width;
+    let height = self.height;
+    let stride = self.width as i32 * 4;
+
+    let buffer = self.buffer.get_or_insert_with(|| {
+      self
+        .pool
+        .create_buffer(
+          width as i32,
+          height as i32,
+          stride,
+          wl_shm::Format::Argb8888,
+        )
+        .expect("create buffer")
+        .0
+    });
+
+    let canvas = match self.pool.canvas(buffer) {
+      Some(canvas) => canvas,
+      None => {
+        // This should be rare, but if the compositor has not released the previous
+        // buffer, we need double-buffering.
+        let (second_buffer, canvas) = self
+          .pool
+          .create_buffer(
+            self.width as i32,
+            self.height as i32,
+            stride,
+            wl_shm::Format::Argb8888,
+          )
+          .expect("create buffer");
+        *buffer = second_buffer;
+        canvas
+      }
+    };
+
+    // Draw to the window:
+    {
+      let shift = self.shift.unwrap_or(0);
+      canvas
+        .chunks_exact_mut(4)
+        .enumerate()
+        .for_each(|(index, chunk)| {
+          let x = ((index + shift as usize) % width as usize) as u32;
+          let y = (index / width as usize) as u32;
+
+          let a = 0xFF;
+          let r = u32::min(((width - x) * 0xFF) / width, ((height - y) * 0xFF) / height);
+          let g = u32::min((x * 0xFF) / width, ((height - y) * 0xFF) / height);
+          let b = u32::min(((width - x) * 0xFF) / width, (y * 0xFF) / height);
+          let color = (a << 24) + (r << 16) + (g << 8) + b;
+
+          let array: &mut [u8; 4] = chunk.try_into().unwrap();
+          *array = color.to_le_bytes();
+        });
+
+      if let Some(shift) = &mut self.shift {
+        *shift = (*shift + 1) % width;
+      }
+    }
+
+    // Damage the entire window
+    self
+      .window
+      .wl_surface()
+      .damage_buffer(0, 0, self.width as i32, self.height as i32);
+
+    // Request our next frame
+    self
+      .window
+      .wl_surface()
+      .frame(qh, self.window.wl_surface().clone());
+
+    // Attach and commit to present.
+    buffer
+      .attach_to(self.window.wl_surface())
+      .expect("buffer attach");
+    self.window.commit();
   }
-  surface.commit();
-  Ok(())
+}
+
+delegate_compositor!(SimpleWindow);
+delegate_output!(SimpleWindow);
+delegate_shm!(SimpleWindow);
+
+delegate_seat!(SimpleWindow);
+delegate_keyboard!(SimpleWindow);
+
+delegate_xdg_shell!(SimpleWindow);
+delegate_xdg_window!(SimpleWindow);
+delegate_activation!(SimpleWindow);
+
+delegate_registry!(SimpleWindow);
+
+impl ProvidesRegistryState for SimpleWindow {
+  fn registry(&mut self) -> &mut RegistryState {
+    &mut self.registry_state
+  }
+  registry_handlers![OutputState, SeatState,];
 }

--- a/espanso-detect/src/evdev/sync/wayland.rs
+++ b/espanso-detect/src/evdev/sync/wayland.rs
@@ -378,6 +378,7 @@ impl ShmHandler for SimpleWindow {
   }
 }
 
+#[allow(clippy::many_single_char_names)]
 impl SimpleWindow {
   pub fn draw(&mut self, _conn: &Connection, qh: &QueueHandle<Self>) {
     let width = self.width;

--- a/espanso-detect/src/evdev/sync/wayland.rs
+++ b/espanso-detect/src/evdev/sync/wayland.rs
@@ -93,7 +93,7 @@ pub fn get_modifiers_state() -> Result<Option<super::ModifiersState>> {
         surface: Some(window.wl_surface().clone()),
         app_id: Some(String::from("Espanso.SyncTool")),
       },
-    )
+    );
   }
 
   // We don't know how large the window will be yet, so lets assume the minimum size we suggested for the
@@ -235,8 +235,8 @@ impl WindowHandler for SimpleWindow {
     debug!("Window configured to: {:?}", configure);
 
     self.buffer = None;
-    self.width = configure.new_size.0.map(|v| v.get()).unwrap_or(256);
-    self.height = configure.new_size.1.map(|v| v.get()).unwrap_or(256);
+    self.width = configure.new_size.0.map_or(256, std::num::NonZeroU32::get);
+    self.height = configure.new_size.1.map_or(256, std::num::NonZeroU32::get);
 
     // Initiate the first draw.
     if self.first_configure {
@@ -379,6 +379,7 @@ impl ShmHandler for SimpleWindow {
 }
 
 #[allow(clippy::many_single_char_names)]
+#[allow(clippy::single_match_else)]
 impl SimpleWindow {
   pub fn draw(&mut self, _conn: &Connection, qh: &QueueHandle<Self>) {
     let width = self.width;


### PR DESCRIPTION
This also fixes the issue with the unresponsive window under wayland.

Should fix #1899, fixes #1826, fixes #1722 and fixes #1776. The cause appears to have been associating a callback with the keyboard created, since this issue is reproducible with the new API if a keyboard_with_repeat is created and a repeat callback passed.