### PR TITLE
Add return value to fix runtime crash on nix + aarch64-darwin

### DIFF
--- a/espanso-detect/src/mac/native.mm
+++ b/espanso-detect/src/mac/native.mm
@@ -137,6 +137,7 @@ void * detect_initialize(EventCallback callback, InitializeOptions options) {
         }
     }];
   });
+  return nullptr;
 }
 
 OSStatus hotkey_event_handler(EventHandlerCallRef _next, EventRef evt, void *userData)


### PR DESCRIPTION
Absence of a return value in a non-void function can be UB and results in a
runtime crash when compiled via nix on aarch64-darwin.

I expect there will be other instances in the codebase; I'm going to
investigate changing the cc-rs incantation to produce a compile-time error to
help identify and correct other instances of this issue.

https://github.com/espanso/espanso/issues/1945
https://github.com/NixOS/nixpkgs/issues/247162
