### PR TITLE
Support non-ASCII characters in triggers on macOS

### DIFF
--- a/espanso-detect/src/mac/native.mm
+++ b/espanso-detect/src/mac/native.mm
@@ -73,8 +73,8 @@ void * detect_initialize(EventCallback callback, InitializeOptions options) {
           inputEvent.key_code = event.keyCode;
 
           const char *chars = [event.characters UTF8String];
-          strncpy(inputEvent.buffer, chars, 23);
-          inputEvent.buffer_len = event.characters.length;
+          strncpy(inputEvent.buffer, chars, 23);  // always preserves NUL terminator at inputEvent.buffer[23]
+          inputEvent.buffer_len = strlen(inputEvent.buffer);  // measure length in bytes, not in Unicode characters/codepoints
 
           // We also send the modifier key status to "correct" missing modifier release events
           if (([event modifierFlags] & NSEventModifierFlagShift) != 0) {


### PR DESCRIPTION
Reports the number of bytes in the UTF-8 encoded character input to the Rust code, as expected there. Formerly the number of Unicode characters/codepoints was reported instead, which did only work for 7-bit ASCII characters.