### PR TITLE
Create a rpm build automatically

### DIFF
--- a/.github/scripts/fedora/Dockerfile
+++ b/.github/scripts/fedora/Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora:40
+
+RUN dnf -y install @development-tools gcc-c++ wl-clipboard libxkbcommon-devel dbus-devel wxGTK-devel.x86_64
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.77.0
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+RUN mkdir espanso && cargo install rust-script --version "0.7.0" && cargo install --force cargo-make --version 0.37.5
+
+COPY . espanso
+
+RUN cd espanso

--- a/.github/scripts/fedora/build_rpm.sh
+++ b/.github/scripts/fedora/build_rpm.sh
@@ -19,4 +19,4 @@ sha256sum espanso-fedora-wayland-amd64.rpm > espanso-fedora-wayland-amd64-sha256
 ls -la
 
 echo "Copying to mounted volume"
-cp espanso-debian-* /shared
+cp espanso-fedora-* /shared

--- a/.github/scripts/fedora/build_rpm.sh
+++ b/.github/scripts/fedora/build_rpm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+echo "Installing cargo-generate-rpm"
+cargo install cargo-generate-rpm --version 0.14.0
+
+cd espanso
+
+echo "Building Wayland"
+cargo make --profile release --env NO_X11=true build-binary
+
+echo "Building Wayland RPM package"
+cargo generate-rpm -p espanso
+
+cd ..
+cp espanso/target/generate-rpm/*.rpm espanso-fedora-wayland-amd64.rpm
+sha256sum espanso-fedora-wayland-amd64.rpm > espanso-fedora-wayland-amd64-sha256.txt
+ls -la
+
+echo "Copying to mounted volume"
+cp espanso-debian-* /shared

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -117,6 +117,28 @@ jobs:
           path: |
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb
+  linux-rpm:
+    needs: ["extract-version", "create-release"]
+    runs-on: fedora-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Build docker image
+        run: |
+          sudo docker build -t espanso-fedora . -f .github/scripts/fedora/Dockerfile
+      - name: Build rpm packages
+        run: |
+          sudo docker run --rm -v "$(pwd):/shared" espanso-fedora espanso/.github/scripts/fedora/build_rpm.sh
+      - uses: actions/upload-artifact@v4
+        name: "Upload artifacts"
+        with:
+          name: Fedora Artifacts
+          path: |
+            espanso-fedora-wayland-amd64.deb
 
 
   macos-intel:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -164,6 +164,33 @@ jobs:
         run: |
           gh release upload ${{ needs.extract-version.outputs.espanso_version }} espanso-debian-x11-amd64.deb espanso-debian-wayland-amd64.deb espanso-debian-x11-amd64-sha256.txt espanso-debian-wayland-amd64-sha256.txt 
 
+  linux-rpm:
+    needs: ["extract-version", "create-release"]
+    runs-on: fedora-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Build docker image
+        run: |
+          sudo docker build -t espanso-fedora . -f .github/scripts/fedora/Dockerfile
+      - name: Build rpm packages
+        run: |
+          sudo docker run --rm -v "$(pwd):/shared" espanso-fedora espanso/.github/scripts/fedora/build_rpm.sh
+      - uses: actions/upload-artifact@v4
+        name: "Upload artifacts"
+        with:
+          name: Fedora Artifacts
+          path: |
+            espanso-fedora-wayland-amd64.deb
+      - name: Upload artifacts to Github Releases (if master)
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          gh release upload ${{ needs.extract-version.outputs.espanso_version }} espanso-fedora-wayland-amd64.deb espanso-fedora-wayland-amd64-sha256.txt 
+
 
   macos-intel:
     needs: ["extract-version", "create-release"]

--- a/espanso/Cargo.toml
+++ b/espanso/Cargo.toml
@@ -101,3 +101,9 @@ depends = "libc6 (>= 2.27), libdbus-1-3 (>= 1.9.14), libgcc1 (>= 1:4.2), libnoti
 # TODO: once this issue [1] is fixed, we should create a variant for
 # wayland to automatically run the setcap script.
 # [1]: https://github.com/mmstick/cargo-deb/issues/151
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/espanso", dest = "/usr/local/bin/espanso", mode = "755" }
+]
+post_install_script = "setcap 'cap_dac_override+p' /usr/local/bin/espanso"


### PR DESCRIPTION
I extended the Github build pipeline to also create a RPM build (for Fedora). Note:
  * Currently only creates the wayland build
  * I don't know how to test the github pipelines unfortunately