### PR TITLE
:green_heart: change `macos-11` for `macos-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: cargo make --env NO_X11=true -- test-binary
   
   build-macos-arm:
-    runs-on: macos-11
+    runs-on: macos-latest
     env:
       WX_WIDGETS_BUILD_OUT_DIR: "${{github.workspace}}/wx-widgets-build"
     steps:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -121,7 +121,7 @@ jobs:
 
   macos-intel:
     needs: ["extract-version"]
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -156,7 +156,7 @@ jobs:
   
   macos-m1:
     needs: ["extract-version"]
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -167,7 +167,7 @@ jobs:
 
   macos-intel:
     needs: ["extract-version", "create-release"]
-    runs-on: macos-11
+    runs-on: macos-latest
     environment: production
 
     steps:
@@ -238,7 +238,7 @@ jobs:
   
   macos-m1:
     needs: ["extract-version", "create-release"]
-    runs-on: macos-11
+    runs-on: macos-latest
     environment: production
 
     steps:
@@ -305,7 +305,7 @@ jobs:
 
   macos-publish-homebrew:
     needs: ["extract-version", "create-release", "macos-m1", "macos-intel"]
-    runs-on: macos-11
+    runs-on: macos-latest
     environment: production
 
     steps:


### PR DESCRIPTION
`macos-11` is going to be deprecated on 28 June 2024, so I'm replacing it with latest