### PR TITLE
:green_heart: fix requirement `create-release`

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -118,9 +118,8 @@ jobs:
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb
   linux-rpm:
-    needs: ["extract-version", "create-release"]
+    needs: ["extract-version"]
     runs-on: fedora-latest
-    environment: production
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI failed because: 
```
The workflow is not valid. .github/workflows/dev-release.yml (Line: 121, Col: 32): Job 'linux-rpm' depends on unknown job 'create-release'.
```