### PR TITLE
:green_heart: remove `rpm` build

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -117,28 +117,29 @@ jobs:
           path: |
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb
-  linux-rpm:
-    needs: ["extract-version"]
-    runs-on: fedora-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Print target version
-        run: |
-          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
-      - name: Build docker image
-        run: |
-          sudo docker build -t espanso-fedora . -f .github/scripts/fedora/Dockerfile
-      - name: Build rpm packages
-        run: |
-          sudo docker run --rm -v "$(pwd):/shared" espanso-fedora espanso/.github/scripts/fedora/build_rpm.sh
-      - uses: actions/upload-artifact@v4
-        name: "Upload artifacts"
-        with:
-          name: Fedora Artifacts
-          path: |
-            espanso-fedora-wayland-amd64.deb
-
+  # linux-rpm:
+  #   needs: ["extract-version"]
+  #   runs-on: fedora-latest
+  #
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Print target version
+  #       run: |
+  #         echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+  #     - name: Build docker image
+  #       run: |
+  #         sudo docker build -t espanso-fedora . -f .github/scripts/fedora/Dockerfile
+  #     - name: Build rpm packages
+  #       run: |
+  #         sudo docker run --rm -v "$(pwd):/shared" espanso-fedora espanso/.github/scripts/fedora/build_rpm.sh
+  #     - uses: actions/upload-artifact@v4
+  #       name: "Upload artifacts"
+  #       with:
+  #         name: Fedora Artifacts
+  #         path: |
+  #           espanso-fedora-wayland-amd64.deb
+  #
 
   macos-intel:
     needs: ["extract-version"]

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -164,33 +164,33 @@ jobs:
         run: |
           gh release upload ${{ needs.extract-version.outputs.espanso_version }} espanso-debian-x11-amd64.deb espanso-debian-wayland-amd64.deb espanso-debian-x11-amd64-sha256.txt espanso-debian-wayland-amd64-sha256.txt 
 
-  linux-rpm:
-    needs: ["extract-version", "create-release"]
-    runs-on: fedora-latest
-    environment: production
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Print target version
-        run: |
-          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
-      - name: Build docker image
-        run: |
-          sudo docker build -t espanso-fedora . -f .github/scripts/fedora/Dockerfile
-      - name: Build rpm packages
-        run: |
-          sudo docker run --rm -v "$(pwd):/shared" espanso-fedora espanso/.github/scripts/fedora/build_rpm.sh
-      - uses: actions/upload-artifact@v4
-        name: "Upload artifacts"
-        with:
-          name: Fedora Artifacts
-          path: |
-            espanso-fedora-wayland-amd64.deb
-      - name: Upload artifacts to Github Releases (if master)
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: |
-          gh release upload ${{ needs.extract-version.outputs.espanso_version }} espanso-fedora-wayland-amd64.deb espanso-fedora-wayland-amd64-sha256.txt 
-
+  # linux-rpm:
+  #   needs: ["extract-version", "create-release"]
+  #   runs-on: fedora-latest
+  #   environment: production
+  #
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Print target version
+  #       run: |
+  #         echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+  #     - name: Build docker image
+  #       run: |
+  #         sudo docker build -t espanso-fedora . -f .github/scripts/fedora/Dockerfile
+  #     - name: Build rpm packages
+  #       run: |
+  #         sudo docker run --rm -v "$(pwd):/shared" espanso-fedora espanso/.github/scripts/fedora/build_rpm.sh
+  #     - uses: actions/upload-artifact@v4
+  #       name: "Upload artifacts"
+  #       with:
+  #         name: Fedora Artifacts
+  #         path: |
+  #           espanso-fedora-wayland-amd64.deb
+  #     - name: Upload artifacts to Github Releases (if master)
+  #       if: ${{ github.ref == 'refs/heads/master' }}
+  #       run: |
+  #         gh release upload ${{ needs.extract-version.outputs.espanso_version }} espanso-fedora-wayland-amd64.deb espanso-fedora-wayland-amd64-sha256.txt 
+  #
 
   macos-intel:
     needs: ["extract-version", "create-release"]


### PR DESCRIPTION
Sadly `fedora-latest` takes so long to start that the job `linux-rpm` fails.

We need to find another way to build the rpm.