### PR TITLE
:memo: clarify `Applications` folder

### DIFF
--- a/espanso-modulo/src/sys/wizard/wizard_gui.cpp
+++ b/espanso-modulo/src/sys/wizard/wizard_gui.cpp
@@ -90,7 +90,7 @@ WizardFrame::WizardFrame( wxWindow* parent, wxWindowID id, const wxString& title
 
 	bSizer22->Add( 0, 20, 0, 0, 5 );
 
-	move_bundle_description = new wxStaticText( move_bundle_panel, wxID_ANY, wxT("Espanso is being run from outside the Applications directory, which prevents it from working correctly.\n\nPlease move the Espanso.app bundle inside your Applications folder and start it again.\n"), wxDefaultPosition, wxDefaultSize, 0 );
+	move_bundle_description = new wxStaticText( move_bundle_panel, wxID_ANY, wxT("Espanso is being run from outside the root Applications directory, which prevents it from working correctly.\n\nPlease move the Espanso.app bundle inside your root /Applications folder and start it again.\n"), wxDefaultPosition, wxDefaultSize, 0 );
 	move_bundle_description->Wrap( 500 );
 	bSizer22->Add( move_bundle_description, 0, wxALL, 10 );
 


### PR DESCRIPTION
Coming from #2012 , we can clarify the error from:

> Espanso is being run from outside the Applications directory, which prevents it from working correctly.\n\nPlease move the Espanso.app bundle inside your Applications folder and start it again.\n

to

> Espanso is being run from outside the **root** Applications directory, which prevents it from working correctly.\n\nPlease move the Espanso.app bundle inside your **root** /Applications folder and start it again.\n