### PR TITLE
:arrow_up: upgrade `bumpalo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"


### PR DESCRIPTION
Dependabot failed to update `bumpalo` back in #1509 , so I upgrade it here manually.

It's a [security concern](https://github.com/espanso/espanso/security/dependabot/16)