### PR TITLE
:arrow_up: upgrade `colored`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,13 +282,12 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "atty",
  "lazy_static",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Another bump in an effort to get rid of `atty`

[security issue](https://github.com/espanso/espanso/security/dependabot)