### PR TITLE
Resolve issue with cursor placement when using multi-byte characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "log",
  "markdown",
  "thiserror",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3168,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/espanso-engine/Cargo.toml
+++ b/espanso-engine/Cargo.toml
@@ -11,6 +11,7 @@ thiserror.workspace = true
 crossbeam.workspace = true
 markdown = "0.3.0"
 html2text = "0.12.0"
+unicode-segmentation = "1.9.0"
 
 [lints]
 workspace = true

--- a/espanso-engine/src/process/middleware/cursor_hint.rs
+++ b/espanso-engine/src/process/middleware/cursor_hint.rs
@@ -21,6 +21,7 @@ use super::super::Middleware;
 use crate::event::{
   effect::CursorHintCompensationEvent, internal::RenderedEvent, Event, EventType,
 };
+use unicode_segmentation::UnicodeSegmentation;
 
 pub struct CursorHintMiddleware {}
 
@@ -64,8 +65,8 @@ fn process_cursor_hint(body: String) -> (String, Option<usize>) {
   if let Some(index) = body.find("$|$") {
     // Convert the byte index to a char index
     let char_str = &body[0..index];
-    let char_index = char_str.chars().count();
-    let total_size = body.chars().count();
+    let char_index = char_str.graphemes(true).count();
+    let total_size = body.graphemes(true).count();
 
     // Remove the $|$ placeholder
     let body = body.replace("$|$", "");


### PR DESCRIPTION
fixes #2062
When using non-ASCII characters in the replace string, the cursor placement is incorrect because the number of backward steps is calculated based on the number of chars instead of graphemes. Some emojis consist of more than one char, for example "⏱️".

**Solution**
Updated the code to count the number of graphemes instead of chars, ensuring correct cursor placement with multi-byte characters.

**Testing**
Ran all existing tests and also compiled it for windows and verified that it now calculates the number of steps correctly.