### PR TITLE
Fix delay between keystrokes on Mac.

### DIFF
--- a/espanso-inject/src/mac/mod.rs
+++ b/espanso-inject/src/mac/mod.rs
@@ -63,7 +63,11 @@ impl Injector for MacInjector {
   fn send_string(&self, string: &str, options: InjectionOptions) -> Result<()> {
     let c_string = CString::new(string)?;
     unsafe {
-      inject_string(c_string.as_ptr(), InjectionOptions::default().delay, options.delay);
+      inject_string(
+        c_string.as_ptr(),
+        InjectionOptions::default().delay,
+        options.delay,
+      );
     }
     Ok(())
   }

--- a/espanso-inject/src/mac/mod.rs
+++ b/espanso-inject/src/mac/mod.rs
@@ -32,7 +32,7 @@ use crate::{keys, InjectionOptions, Injector};
 #[allow(improper_ctypes)]
 #[link(name = "espansoinject", kind = "static")]
 extern "C" {
-  pub fn inject_string(string: *const c_char, delay: i32);
+  pub fn inject_string(string: *const c_char, default_delay: i32, delay: i32);
   pub fn inject_separate_vkeys(vkey_array: *const i32, vkey_count: i32, delay: i32);
   pub fn inject_vkeys_combination(vkey_array: *const i32, vkey_count: i32, delay: i32);
 }
@@ -63,7 +63,7 @@ impl Injector for MacInjector {
   fn send_string(&self, string: &str, options: InjectionOptions) -> Result<()> {
     let c_string = CString::new(string)?;
     unsafe {
-      inject_string(c_string.as_ptr(), options.delay);
+      inject_string(c_string.as_ptr(), InjectionOptions::default().delay, options.delay);
     }
     Ok(())
   }

--- a/espanso-inject/src/mac/native.h
+++ b/espanso-inject/src/mac/native.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 // Inject a complete string using the KEYEVENTF_UNICODE flag
-extern "C" void inject_string(char * string, int32_t delay);
+extern "C" void inject_string(char * string, int32_t default_delay, int32_t delay);
 
 // Send a sequence of vkey presses and releases
 extern "C" void inject_separate_vkeys(int32_t *vkey_array, int32_t vkey_count, int32_t delay);

--- a/espanso-inject/src/mac/native.mm
+++ b/espanso-inject/src/mac/native.mm
@@ -54,7 +54,6 @@ void inject_string(char *string, int32_t default_delay, int32_t delay)
       usleep(udelay);
     }
 
-
     // Because of a bug ( or undocumented limit ) of the CGEventKeyboardSetUnicodeString method
     // the string gets truncated after 20 characters, so we need to send multiple events.
 

--- a/espanso-inject/src/mac/native.mm
+++ b/espanso-inject/src/mac/native.mm
@@ -54,20 +54,13 @@ void inject_string(char *string, int32_t delay)
       usleep(udelay);
     }
 
-    // Because of a bug ( or undocumented limit ) of the CGEventKeyboardSetUnicodeString method
-    // the string gets truncated after 20 characters, so we need to send multiple events.
-
-    int i = 0;
-    while (i < buffer.size()) {
-      int chunk_size = 20;
-      if ((i+chunk_size) >  buffer.size()) {
-        chunk_size = buffer.size() - i;
-      }
-
+    // Issue a single char per call, like the other platforms
+    for (int i = 0 ; i < buffer.size(); i++)
+    {
       UniChar * offset_buffer = buffer.data() + i;
       CGEventRef e = CGEventCreateKeyboardEvent(NULL, 0x31, true);
       CGEventSetLocation(e, ESPANSO_POINT_MARKER);
-      CGEventKeyboardSetUnicodeString(e, chunk_size, offset_buffer);
+      CGEventKeyboardSetUnicodeString(e, 1, offset_buffer);
       CGEventPost(kCGHIDEventTap, e);
       CFRelease(e);
 
@@ -81,8 +74,6 @@ void inject_string(char *string, int32_t delay)
       CFRelease(e2);
 
       usleep(udelay);
-
-      i += chunk_size;
     }
   });
 }


### PR DESCRIPTION
In the mac implementation, the keystrokes doesn't have the same delay as in other platforms.

The injection is made in chunks of 20 chars. This fixes that, respecting the `inject_delay` config.

Fix the Mac issue in #2038