### PR TITLE
remove 2048 byte clipboard limit for windows

### DIFF
--- a/espanso-clipboard/src/win32/ffi.rs
+++ b/espanso-clipboard/src/win32/ffi.rs
@@ -21,6 +21,7 @@ use std::os::raw::c_char;
 
 #[link(name = "espansoclipboard", kind = "static")]
 extern "C" {
+  pub fn clipboard_get_length() -> i32;
   pub fn clipboard_get_text(buffer: *mut u16, buffer_size: i32) -> i32;
   pub fn clipboard_set_text(text: *const u16) -> i32;
   pub fn clipboard_set_image(image_path: *const u16) -> i32;

--- a/espanso-clipboard/src/win32/mod.rs
+++ b/espanso-clipboard/src/win32/mod.rs
@@ -37,7 +37,13 @@ impl Win32Clipboard {
 
 impl Clipboard for Win32Clipboard {
   fn get_text(&self, _: &ClipboardOperationOptions) -> Option<String> {
-    let mut buffer: [u16; 2048] = [0; 2048];
+    // get the clipbard size
+    let length = unsafe { ffi::clipboard_get_length() };
+    if length <= 0 {
+      return None;
+    }
+    // allocate the buffer
+    let mut buffer: Vec<u16> = vec![0; length as usize];
     let native_result =
       unsafe { ffi::clipboard_get_text(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) };
     if native_result > 0 {

--- a/espanso-clipboard/src/win32/native.cpp
+++ b/espanso-clipboard/src/win32/native.cpp
@@ -42,6 +42,33 @@
 
 #include <Windows.h>
 
+int32_t clipboard_get_length() {
+    // Open the clipboard
+    if (!OpenClipboard(NULL)) {
+        return -1; // Failed to open clipboard
+    }
+
+    // Check if the clipboard contains text data
+    HANDLE hData = GetClipboardData(CF_UNICODETEXT);
+    if (hData == NULL) {
+        CloseClipboard();
+        return -1; // No text data in clipboard
+    }
+
+    // Get the size of the clipboard data
+    SIZE_T size = GlobalSize(hData);
+    if (size == 0) {
+        CloseClipboard();
+        return -1; // Failed to get size
+    }
+
+    // Close the clipboard
+    CloseClipboard();
+
+    // Return the size of the clipboard data
+    return static_cast<int32_t>(size);
+}
+
 int32_t clipboard_get_text(wchar_t *buffer, int32_t buffer_size)
 {
   int32_t result = 0;

--- a/espanso-clipboard/src/win32/native.h
+++ b/espanso-clipboard/src/win32/native.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 
+extern "C" int32_t clipboard_get_length();
 extern "C" int32_t clipboard_get_text(wchar_t * buffer, int32_t buffer_size);
 extern "C" int32_t clipboard_set_text(wchar_t * text);
 extern "C" int32_t clipboard_set_image(wchar_t * image);


### PR DESCRIPTION
This resolves #1612 and #2051 on Windows. The previously hardcoded 2048-character clipboard size is now replaced with an adaptive size based on the actual clipboard content length.
