### PR TITLE
remove 2048 byte clipboard limit for macOS

### DIFF
--- a/espanso-clipboard/src/cocoa/ffi.rs
+++ b/espanso-clipboard/src/cocoa/ffi.rs
@@ -21,6 +21,7 @@ use std::os::raw::c_char;
 
 #[link(name = "espansoclipboard", kind = "static")]
 extern "C" {
+  pub fn clipboard_get_length() -> i32;
   pub fn clipboard_get_text(buffer: *mut c_char, buffer_size: i32) -> i32;
   pub fn clipboard_set_text(text: *const c_char) -> i32;
   pub fn clipboard_set_image(image_path: *const c_char) -> i32;

--- a/espanso-clipboard/src/cocoa/mod.rs
+++ b/espanso-clipboard/src/cocoa/mod.rs
@@ -28,6 +28,7 @@ use crate::{Clipboard, ClipboardOperationOptions};
 use anyhow::Result;
 use log::error;
 use thiserror::Error;
+use std::os::raw::c_char;
 
 pub struct CocoaClipboard {}
 
@@ -39,9 +40,17 @@ impl CocoaClipboard {
 
 impl Clipboard for CocoaClipboard {
   fn get_text(&self, _: &ClipboardOperationOptions) -> Option<String> {
-    let mut buffer: [i8; 2048] = [0; 2048];
+    // get the clipbard size
+    let length = unsafe { ffi::clipboard_get_length() };
+    if length <= 0 {
+        return None;
+    }
+
+    // allocate the buffer with extra space for null terminator
+    let mut buffer: Vec<c_char> = vec![0; (length as usize) + 1];
     let native_result =
-      unsafe { ffi::clipboard_get_text(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) };
+      unsafe { ffi::clipboard_get_text(buffer.as_mut_ptr(), buffer.len() as i32) };
+
     if native_result > 0 {
       let string = unsafe { CStr::from_ptr(buffer.as_ptr()) };
       Some(string.to_string_lossy().to_string())

--- a/espanso-clipboard/src/cocoa/mod.rs
+++ b/espanso-clipboard/src/cocoa/mod.rs
@@ -27,8 +27,8 @@ use std::{
 use crate::{Clipboard, ClipboardOperationOptions};
 use anyhow::Result;
 use log::error;
-use thiserror::Error;
 use std::os::raw::c_char;
+use thiserror::Error;
 
 pub struct CocoaClipboard {}
 
@@ -43,7 +43,7 @@ impl Clipboard for CocoaClipboard {
     // get the clipbard size
     let length = unsafe { ffi::clipboard_get_length() };
     if length <= 0 {
-        return None;
+      return None;
     }
 
     // allocate the buffer with extra space for null terminator

--- a/espanso-clipboard/src/cocoa/native.h
+++ b/espanso-clipboard/src/cocoa/native.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 
+extern "C" int32_t clipboard_get_length();
 extern "C" int32_t clipboard_get_text(char * buffer, int32_t buffer_size);
 extern "C" int32_t clipboard_set_text(char * text);
 extern "C" int32_t clipboard_set_image(char * image_path);


### PR DESCRIPTION
This resolves #1612 and #2051 on macOS, similar to the attempt #2085 on Windows.

The fix has been tested with multi-byte characters and large clipboard contents, even exceeding 10 MB. There is a caveat regarding memory management on macOS: Real and private memory are released as expected after copying large clipboard contents, but virtual memory still gradually increases over time. This PR doesn't resolve Espanso's general memory release issues on macOS, but it doesn't worsen them either. But it simplifies debugging by allowing tests with clipboard contents larger than 2 bytes.

Before this is released, it would be great if someone with more experience than I have to review not only this PR but also the overall memory management of Espanso (#1675). Especially since Espanso doesn't use ARC, I suspect there are parts of the code that could lead to leaks under certain circumstances. Probably in addition to [the block](https://github.com/espanso/espanso/blob/dev/espanso-detect/src/mac/native.mm#L62) Federico already identified in #1675.

The coding style in these files wasn't very consistent yet, so I maintained alignment on a per-file basis. Comments were added in a manner similar to those in the code for Windows.