### PR TITLE
Add question in template issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: ❓ Question
+    url: https://discord.gg/DFcCNDg7bB
+    about: Do you have a question instead of an issue? Meet us in the Discord!
   - name: 📖 Espanso Documentation
     url: https://espanso.org/docs/
     about: Our Espanso documentation shows you how to configure matches, use packages and much more.
-  - name: 💬 Discord
-    url: https://discord.gg/DFcCNDg7bB
-    about: Our official Discord where you can connect with our community.
-  - name: ❓ Reddit
+  - name: 🧵 Reddit
     url: https://www.reddit.com/r/espanso/
     about: Our official Reddit community in which you can ask questions and receive updates on Espanso.


### PR DESCRIPTION
Currently when you create an issue, it shows this dashboard:
![image](https://github.com/user-attachments/assets/09cdfe02-2357-4e25-aa04-4f3957af366e)

But people is confused when they only have a question, they probably don't think it's a bug, but they don't know if a thing is possible, or if it is, how to do it.

That's why I edited the line of Discord to redirect questions to Discord. We have the link in a bunch of places, so it would be weird to click the button `New Issue` and read `Join the discord` inside (not an issue type).

If we change the sentence to: we respond any questions in our discord! we solve this problem of users not knowing about the software, not because it's a bug of espanso (even if it could be after a discussion!)