### PR TITLE
:recycle: restore the `$auto` in cargo-deb dependencies

### DIFF
--- a/.github/scripts/ubuntu/build_deb.sh
+++ b/.github/scripts/ubuntu/build_deb.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Installing cargo-deb"
-cargo install cargo-deb --version 1.44.1
+cargo install cargo-deb
 
 cd espanso
 

--- a/espanso/Cargo.toml
+++ b/espanso/Cargo.toml
@@ -91,16 +91,13 @@ const_format = "0.2.14"
 regex.workspace = true
 
 [package.metadata.deb]
-maintainer = "Federico Terzi <federicoterzi96@gmail.com>"
-depends = "libc6 (>= 2.27), libdbus-1-3 (>= 1.9.14), libgcc1 (>= 1:4.2), libnotify-bin, libstdc++6 (>=6), libwxgtk3.0-gtk3-0v5 (>= 3.0.4+dfsg) | libwxgtk3.2-1, libx11-6, libxcb1, libxkbcommon0 (>= 0.5.0), libxtst6, systemd, xclip"
+maintainer = "Auca Coyan <aucacoyan@gmail.com>"
+depends = "$auto"
 section = "utility"
 license-file = ["../LICENSE", "1"]
 
 [package.metadata.deb.variants.wayland]
-depends = "libc6 (>= 2.27), libdbus-1-3 (>= 1.9.14), libgcc1 (>= 1:4.2), libnotify-bin, libstdc++6 (>= 5), libwxgtk3.0-gtk3-0v5 (>= 3.0.4+dfsg) | libwxgtk3.2-1, libxkbcommon0 (>= 0.5.0), systemd, wl-clipboard"
-# TODO: once this issue [1] is fixed, we should create a variant for
-# wayland to automatically run the setcap script.
-# [1]: https://github.com/mmstick/cargo-deb/issues/151
+depends = "$auto"
 
 [package.metadata.generate-rpm]
 assets = [


### PR DESCRIPTION
This is related to #1849 and also maybe fixes #1793
with `$auto` in the dependencies
