### PR TITLE
:bug: change pinned `1.77` rustc version for a stable rustc version

### DIFF
--- a/.github/scripts/Dockerfile
+++ b/.github/scripts/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get update \
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.77.0
+    PATH=/usr/local/cargo/bin:$PATH
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
@@ -26,7 +25,7 @@ RUN set -eux; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \

--- a/.github/scripts/fedora/Dockerfile
+++ b/.github/scripts/fedora/Dockerfile
@@ -4,8 +4,7 @@ RUN dnf -y install @development-tools gcc-c++ wl-clipboard libxkbcommon-devel db
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.77.0
+    PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
the CI was getting an error about rust 1.77

```
...
53.25   Downloaded run_script v0.10.1
53.27   Downloaded rustls v0.23.20
53.28   Downloaded rustix v0.38.42
53.55   Downloaded shell2batch v0.4.5
53.59   Downloaded rust_info v0.3.3
53.65 error: failed to compile `cargo-make v0.37.5`, intermediate artifacts can be found at `/tmp/cargo-installsAnE9B`.
53.65 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
53.65 
53.65 Caused by:
53.65   package `cargo-platform v0.1.9` cannot be built because it requires rustc 1.78 or newer, while the currently active rustc version is 1.77.0
53.65   Try re-running cargo install with `--locked`
------
Dockerfile:36
--------------------
  34 |         rustc --version;
  35 |     
  36 | >>> RUN mkdir espanso && cargo install rust-script --version "0.7.0" && cargo install --force cargo-make --version 0.37.5
  37 |     
  38 |     COPY . espanso
--------------------
ERROR: failed to solve: process "/bin/sh -c mkdir espanso && cargo install rust-script --version \"0.7.0\" && cargo install --force cargo-make --version 0.37.5" did not complete successfully: exit code: 101
```