### PR TITLE
:bug: fix missing readme in cargo deb

### DIFF
--- a/.github/scripts/ubuntu/build_deb.sh
+++ b/.github/scripts/ubuntu/build_deb.sh
@@ -8,10 +8,10 @@ cargo install cargo-deb
 cd espanso
 
 echo "Building X11 deb package"
-cargo deb -p espanso -- --no-default-features --features "modulo vendored-tls"
+cargo deb --package espanso -- --no-default-features --features "modulo vendored-tls"
 
 echo "Building Wayland deb package"
-cargo deb -p espanso --variant wayland -- --no-default-features --features "modulo wayland vendored-tls"
+cargo deb --package espanso --variant wayland -- --no-default-features --features "modulo wayland vendored-tls"
 
 cd ..
 cp espanso/target/debian/espanso_*.deb espanso-debian-x11-amd64.deb

--- a/espanso/Cargo.toml
+++ b/espanso/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.2.2"
 authors = ["Federico Terzi <federicoterzi96@gmail.com>"]
 license = "GPL-3.0"
 description = "Cross-platform Text Expander written in Rust"
-readme = "README.md"
+readme = "../README.md"
 homepage = "https://github.com/espanso/espanso"
 edition = "2021"
 


### PR DESCRIPTION
`README.md` for `../README.md`

Pro tip: you can do
```bash
cargo deb --verbose ...<rest of the cargo deb cmd>
```
to see what is going on