### PR TITLE
:arrow_up: upgrade `rust-script` to latest (not locked)

### DIFF
--- a/.github/scripts/Dockerfile
+++ b/.github/scripts/Dockerfile
@@ -32,7 +32,7 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-RUN mkdir espanso && cargo install rust-script --version "0.7.0" && cargo install --force cargo-make --version 0.37.5
+RUN mkdir espanso && cargo install rust-script && cargo install --force cargo-make --version 0.37.5
 
 COPY . espanso
 

--- a/.github/scripts/fedora/Dockerfile
+++ b/.github/scripts/fedora/Dockerfile
@@ -8,7 +8,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-RUN mkdir espanso && cargo install rust-script --version "0.7.0" && cargo install --force cargo-make --version 0.37.5
+RUN mkdir espanso && cargo install rust-script && cargo install --force cargo-make --version 0.37.5
 
 COPY . espanso
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install -y libx11-dev libxtst-dev libxkbcommon-dev libdbus-1-dev libwxgtk3.*-dev
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install cargo-make --version 0.37.5
       # wxWidgets builds (internal to espanso-modulo) are by far the largest bottleneck
       # in the current pipeline, so we cache the results for a faster compilation process
@@ -81,7 +81,7 @@ jobs:
           sudo apt-get install -y libx11-dev libxtst-dev libxkbcommon-dev libdbus-1-dev libwxgtk3.*-dev
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install cargo-make --version 0.37.5
       - name: Run test suite
         run: cargo make test-binary
@@ -101,7 +101,7 @@ jobs:
           sudo apt-get install -y libxkbcommon-dev libwxgtk3.*-dev libdbus-1-dev
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install cargo-make --version 0.37.5
       - name: Build
         run: cargo make --env NO_X11=true -- build-binary
@@ -125,7 +125,7 @@ jobs:
           sudo apt-get install -y libxkbcommon-dev libwxgtk3.*-dev libdbus-1-dev
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install cargo-make --version 0.37.5
       - name: Run test suite
         run: cargo make --env NO_X11=true -- test-binary
@@ -141,7 +141,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install cargo-make --version 0.37.5
       - name: "Cache wxWidgets builds"
         if: ${{ runner.os != 'Linux' }}

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -58,7 +58,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Test
         run: cargo make --profile release -- test-binary
@@ -173,7 +173,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Test
         run: cargo make --profile release -- test-binary
@@ -226,7 +226,7 @@ jobs:
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Build
         run: cargo make --env BUILD_ARCH=aarch64-apple-darwin --profile release -- create-bundle

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -42,7 +42,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Test
         run: cargo make --profile release -- test-binary
@@ -152,7 +152,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Test
         run: cargo make --profile release -- test-binary
@@ -189,7 +189,7 @@ jobs:
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Build
         run: cargo make --env BUILD_ARCH=aarch64-apple-darwin --profile release -- create-bundle

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -62,7 +62,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Test
         run: cargo make --profile release -- test-binary
@@ -204,7 +204,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Test
         run: cargo make --profile release -- test-binary
@@ -277,7 +277,7 @@ jobs:
         run: rustup update && rustup target add aarch64-apple-darwin
       - name: Install rust-script and cargo-make
         run: |
-          cargo install rust-script --version "0.7.0"
+          cargo install rust-script
           cargo install --force cargo-make --version 0.37.5
       - name: Build
         run: cargo make --env BUILD_ARCH=aarch64-apple-darwin --profile release -- create-bundle

--- a/Compilation.md
+++ b/Compilation.md
@@ -17,7 +17,7 @@ These are the basic tools required to build espanso:
 steps. You can install it by running:
 
 ```bash
-cargo install rust-script --version "0.7.0"
+cargo install rust-script
 cargo install --force cargo-make --version 0.37.5
 ```
 


### PR DESCRIPTION
I removed the ` --version "0.7.0"` lock from
```
cargo install rust-script --version "0.7.0"
```
