### PR TITLE
Removed CI workaround and fixed compilation on macOS ARM

### DIFF
--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -180,8 +180,7 @@ fn build_native() {
     arch => panic!("unsupported arch {arch}"),
   };
 
-  let is_arm64_ci = 
-      std::env::var("CI").unwrap_or_default() == "true" && target_arch == "arm64";
+  let is_arm64_ci = std::env::var("CI").unwrap_or_default() == "true" && target_arch == "arm64";
 
   if !out_wx_dir.is_dir() {
     // Extract the wxWidgets archive
@@ -197,17 +196,21 @@ fn build_native() {
     std::fs::create_dir_all(&build_dir).expect("unable to create build-cocoa directory");
 
     let configure_args: [&str; 4] = [
-        "--disable-shared",
-        "--without-libtiff",
-        "--with-macosx-version-min=10.13",
-        if is_arm64_ci { "--enable-universal-binary=arm64,x86_64" } else { &format!("--enable-macosx_arch={target_arch}") }
+      "--disable-shared",
+      "--without-libtiff",
+      "--with-macosx-version-min=10.13",
+      if is_arm64_ci {
+        "--enable-universal-binary=arm64,x86_64"
+      } else {
+        &format!("--enable-macosx_arch={target_arch}")
+      },
     ];
 
     let mut handle = Command::new(out_wx_dir.join("configure"))
-        .current_dir(build_dir.to_string_lossy().to_string())
-        .args(configure_args.iter())
-        .spawn()
-        .expect("failed to execute configure");
+      .current_dir(build_dir.to_string_lossy().to_string())
+      .args(configure_args.iter())
+      .spawn()
+      .expect("failed to execute configure");
 
     if !handle
       .wait()

--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -180,8 +180,8 @@ fn build_native() {
     arch => panic!("unsupported arch {arch}"),
   };
 
-  let should_use_ci_m1_workaround =
-    std::env::var("CI").unwrap_or_default() == "true" && target_arch == "arm64";
+  let is_arm64_ci = 
+      std::env::var("CI").unwrap_or_default() == "true" && target_arch == "arm64";
 
   if !out_wx_dir.is_dir() {
     // Extract the wxWidgets archive
@@ -196,36 +196,18 @@ fn build_native() {
     let build_dir = out_wx_dir.join("build-cocoa");
     std::fs::create_dir_all(&build_dir).expect("unable to create build-cocoa directory");
 
-    let mut handle = if should_use_ci_m1_workaround {
-      // Because of a configuration problem on the GitHub CI pipeline,
-      // we need to use a series of workarounds to build for M1 machines.
-      // See: https://github.com/actions/virtual-environments/issues/3288#issuecomment-830207746
-      Command::new(out_wx_dir.join("configure"))
+    let configure_args: [&str; 4] = [
+        "--disable-shared",
+        "--without-libtiff",
+        "--with-macosx-version-min=10.13",
+        if is_arm64_ci { "--enable-universal-binary=arm64,x86_64" } else { &format!("--enable-macosx_arch={target_arch}") }
+    ];
+
+    let mut handle = Command::new(out_wx_dir.join("configure"))
         .current_dir(build_dir.to_string_lossy().to_string())
-        .args([
-          "--disable-shared",
-          "--without-libtiff",
-          "--without-liblzma",
-          "--with-libjpeg=builtin",
-          "--with-libpng=builtin",
-          "--enable-universal-binary=arm64,x86_64",
-        ])
+        .args(configure_args.iter())
         .spawn()
-        .expect("failed to execute configure")
-    } else {
-      Command::new(out_wx_dir.join("configure"))
-        .current_dir(build_dir.to_string_lossy().to_string())
-        .args([
-          "--disable-shared",
-          "--without-libtiff",
-          "--without-liblzma",
-          "--with-libjpeg=builtin",
-          "--with-libpng=builtin",
-          &format!("--enable-macosx_arch={target_arch}"),
-        ])
-        .spawn()
-        .expect("failed to execute configure")
-    };
+        .expect("failed to execute configure");
 
     if !handle
       .wait()
@@ -257,7 +239,7 @@ fn build_native() {
 
   // If using the M1 CI workaround, convert all the universal libraries to arm64 ones
   // This is needed until https://github.com/rust-lang/rust/issues/55235 is fixed
-  if should_use_ci_m1_workaround {
+  if is_arm64_ci {
     convert_fat_libraries_to_arm(&out_wx_dir.join("build-cocoa").join("lib"));
     convert_fat_libraries_to_arm(&out_wx_dir.join("build-cocoa"));
   }


### PR DESCRIPTION
Apparently whatever required multiple configuration changes to the compilation of wxWidgets is no longer necessary ([previously referred issue](https://github.com/actions/virtual-environments/issues/3288#issuecomment-830207746) is closed).

This has the side-effect of using the system's libpng (rather than wxWidgets' ancient fork) on compilation. That change fixes a compilation issue on ARM MacOS, caused by requiring a header file that is no longer present (fp.h).