### PR TITLE
:green_heart: missing ignore for the pull requests and some typos in the docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - master
       - dev
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ to the user documentation it's [on the webpage](https://espanso.org/).
 
 - `./docs` is the source directory of the book
 - `./docs/src/SUMMARY.md` configures the order of the menu on the left hand side
-  of the book ([more info here](https://rust-lang.github.io/mdBook/format/summary.html).
+  of the book ([more info here](https://rust-lang.github.io/mdBook/format/summary.html)).
 "Without this file, there is no book."
 - `./docs/assets` stores all the non-markdown content (screenshots, gifs) to be
   used.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,11 +9,10 @@ to the user documentation it's [on the webpage](https://espanso.org/).
 
 - `./docs` is the source directory of the book
 - `./docs/src/SUMMARY.md` configures the order of the menu on the left hand side
-  of the book (more info here). "Without this file, there is no book."
+  of the book ([more info here](https://rust-lang.github.io/mdBook/format/summary.html).
+"Without this file, there is no book."
 - `./docs/assets` stores all the non-markdown content (screenshots, gifs) to be
   used.
-- `./theme` stores general files to be used by mdbook to configure the look and
-  feel of the book (more info here).
 
 ## Building instructions (Install mdBook)
 


### PR DESCRIPTION
I fixed the CI ignore for the docs.
Also,
- remove the `theme` section (unused)
- and add the relevant link to the reference of `SUMMARY.md`