### PR TITLE
docs: setup dark theme for logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-![espanso](images/logo_extended.png)
+<p align="center">
+  <picture>
+    <source srcset="images/logo_extended.png" media="(prefers-color-scheme: light)" height="" alt="expanso logo light">
+    <img src="images/logo_extended_dark.png" height="" alt="expanso logo dark">
+  </picture>
+</p>
 
 > A cross-platform Text Expander written in Rust
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
-    <source srcset="images/logo_extended.png" media="(prefers-color-scheme: light)" height="" alt="expanso logo light">
-    <img src="images/logo_extended_dark.png" height="" alt="expanso logo dark">
+    <source srcset="images/logo_extended.png" media="(prefers-color-scheme: light)" height="" alt="espanso logo light">
+    <img src="images/logo_extended_dark.png" height="" alt="espanso logo dark">
   </picture>
 </p>
 


### PR DESCRIPTION
This is more of an unfinished template since there is currently no dark themed logo in the repository. This pull request should not be merged until a dark themed logo has been added to the repository, else the espanso logo will not be shown for user accounts with dark theme enabled.

The file name used is `logo_extended_dark.png` but this can be edited to the author's preference.