### PR TITLE
:see_no_evil: add rust section in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ venv/
 # Windows
 Espanso-Win-Installer-x86_64*
 Espanso-Win-Portable-x86_64*
+
+# rust
+mutants.out*
+


### PR DESCRIPTION
adding an exception for `cargo-mutants`

```
mutants.out*
```