### PR TITLE
Add CTRL+N and CTRL+P to navigate the search frame

### DIFF
--- a/espanso-modulo/src/sys/search/search.cpp
+++ b/espanso-modulo/src/sys/search/search.cpp
@@ -299,6 +299,14 @@ void SearchFrame::OnCharEvent(wxKeyEvent &event)
     {
         SelectPrevious();
     }
+    else if (event.GetKeyCode() == WXK_CONTROL_N)
+    {
+        SelectNext();
+    }
+    else if (event.GetKeyCode() == WXK_CONTROL_P)
+    {
+        SelectPrevious();
+    }
     else if (event.GetKeyCode() == WXK_RETURN)
     {
         Submit();


### PR DESCRIPTION
This pull request aims to enhance the navigation within the Espanso search frame by adding support for `Ctrl+n` and `Ctrl+p` keybindings. These keybindings are commonly used for navigating down and up in lists, respectively, and their inclusion will improve the user experience for those familiar with these shortcuts.

Currently, the `Ctrl+N` and `Ctrl+P` keybindings are not detected for an unknown reason. Doing the following works:

```cpp
    else if (event.GetUnicodeKey() == 'n')
    { // n
        SelectNext();
    }

```

However, when I check for `Ctrl+<key>` with 

```cpp
    else if (event.GetUnicodeKey() == 'n')
    { // Ctrl + n
        if (wxGetKeyState(WXK_RAW_CONTROL)) // I use WXK_RAW_CONTROL here because we also want to use control on macOS and not the CMD key
        {
            SelectNext();
        } else {
            event.Skip();
        }
    }
```

it doesn't work. I would appreciate some help that points me into the right direction why this doesn't work or how I could debug such an issue.

I'm currently working and testing on Mac.