### PR TITLE
Detect window for wayland with kdotool (KDE only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cc",
+ "espanso-package",
  "log",
  "widestring",
 ]

--- a/espanso-info/Cargo.toml
+++ b/espanso-info/Cargo.toml
@@ -12,6 +12,7 @@ wayland = []
 [dependencies]
 log.workspace = true
 anyhow.workspace = true
+espanso-package = { path = "../espanso-package" }
 
 [lints]
 workspace = true

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -19,7 +19,17 @@
 
 use crate::{AppInfo, AppInfoProvider};
 
+use std::process::Command;
+
 pub(crate) struct WaylandAppInfoProvider {}
+
+fn empty_app_info() -> AppInfo {
+    AppInfo {
+        title: None,
+        exec: Some("Maybe missing kdotool?".into()),
+        class: None,
+    }
+}
 
 impl WaylandAppInfoProvider {
     pub fn new() -> Self {
@@ -29,11 +39,34 @@ impl WaylandAppInfoProvider {
 
 impl AppInfoProvider for WaylandAppInfoProvider {
     // TODO: can we read these info on Wayland?
+    // maybe
     fn get_info(&self) -> AppInfo {
-        AppInfo {
-            title: None,
-            exec: None,
-            class: None,
-        }
+        let class = match Command::new("kdotool")
+            .arg("getactivewindow")
+            .arg("getwindowclassname")
+            .output()
+        {
+            Ok(out) => {
+                let class_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                Some(class_)
+            }
+            Err(_) => return empty_app_info(),
+        };
+
+        let title = match Command::new("kdotool")
+            .arg("getactivewindow")
+            .arg("getwindowname")
+            .output()
+        {
+            Ok(out) => {
+                let title_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                Some(title_)
+            }
+            Err(_) => None,
+        };
+
+        let exec = Some("maybe have kdotool?".into());
+
+        AppInfo { title, exec, class }
     }
 }

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -18,6 +18,7 @@
  */
 
 use crate::{AppInfo, AppInfoProvider};
+use espanso_package::info_println;
 
 use std::process::Command;
 
@@ -54,7 +55,10 @@ impl AppInfoProvider for WaylandAppInfoProvider {
                 let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
                 Some(class_)
             }
-            Err(_) => return empty_app_info(),
+            Err(_) => {
+                info_println!("kdotool missing or not available for the current wayland DE.");
+                return empty_app_info();
+            }
         };
 
         let title = match Command::new("kdotool")

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -47,7 +47,11 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             .output()
         {
             Ok(out) => {
-                let class_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                let mut __stdout = out.stdout;
+                if !__stdout.is_empty() {
+                    __stdout.pop();
+                }
+                let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
                 Some(class_)
             }
             Err(_) => return empty_app_info(),
@@ -59,7 +63,11 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             .output()
         {
             Ok(out) => {
-                let title_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                let mut __stdout = out.stdout;
+                if !__stdout.is_empty() {
+                    __stdout.pop();
+                }
+                let title_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
                 Some(title_)
             }
             Err(_) => None,
@@ -71,7 +79,11 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             .output()
         {
             Ok(out) => {
-                let pid_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                let mut __stdout = out.stdout;
+                if !__stdout.is_empty() {
+                    __stdout.pop();
+                }
+                let pid_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
                 Some(pid_)
                 // match Command::new("readlink")
                 //     .arg(format!("/proc/{}/exe", pid_))

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -26,7 +26,7 @@ pub(crate) struct WaylandAppInfoProvider {}
 fn empty_app_info() -> AppInfo {
     AppInfo {
         title: None,
-        exec: Some("Missing kdotool!".into()),
+        exec: None,
         class: None,
     }
 }

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -42,23 +42,20 @@ impl AppInfoProvider for WaylandAppInfoProvider {
     // TODO: can we read these info on Wayland?
     // maybe
     fn get_info(&self) -> AppInfo {
-        let class = match Command::new("kdotool")
+        let class = if let Ok(out) = Command::new("kdotool")
             .arg("getactivewindow")
             .arg("getwindowclassname")
             .output()
         {
-            Ok(out) => {
-                let mut __stdout = out.stdout;
-                if !__stdout.is_empty() {
-                    __stdout.pop();
-                }
-                let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
-                Some(class_)
+            let mut __stdout = out.stdout;
+            if !__stdout.is_empty() {
+                __stdout.pop();
             }
-            Err(_) => {
-                info_println!("kdotool missing or not available for the current wayland DE.");
-                return empty_app_info();
-            }
+            let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
+            Some(class_)
+        } else {
+            info_println!("kdotool missing or not available for the current wayland DE.");
+            return empty_app_info();
         };
 
         let title = match Command::new("kdotool")
@@ -89,7 +86,7 @@ impl AppInfoProvider for WaylandAppInfoProvider {
                 }
                 let pid_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
                 match Command::new("readlink")
-                    .arg(format!("/proc/{}/exe", pid_))
+                    .arg(format!("/proc/{pid_}/exe"))
                     .output()
                 {
                     Ok(out) => {

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -72,17 +72,18 @@ impl AppInfoProvider for WaylandAppInfoProvider {
         {
             Ok(out) => {
                 let pid_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
-                match Command::new("readlink")
-                    .arg(format!("/proc/{}/exe", pid_))
-                    .output()
-                {
-                    Ok(out) => {
-                        let exec_ =
-                            String::from_utf8(out.stdout).expect("Error decoding from utf8");
-                        Some(exec_)
-                    }
-                    Err(_) => None,
-                }
+                Some(pid_)
+                // match Command::new("readlink")
+                //     .arg(format!("/proc/{}/exe", pid_))
+                //     .output()
+                // {
+                //     Ok(out) => {
+                //         let exec_ =
+                //             String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                //         Some(exec_)
+                //     }
+                //     Err(_) => None,
+                // }
             }
             Err(_) => None,
         };

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -84,18 +84,20 @@ impl AppInfoProvider for WaylandAppInfoProvider {
                     __stdout.pop();
                 }
                 let pid_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
-                Some(pid_)
-                // match Command::new("readlink")
-                //     .arg(format!("/proc/{}/exe", pid_))
-                //     .output()
-                // {
-                //     Ok(out) => {
-                //         let exec_ =
-                //             String::from_utf8(out.stdout).expect("Error decoding from utf8");
-                //         Some(exec_)
-                //     }
-                //     Err(_) => None,
-                // }
+                match Command::new("readlink")
+                    .arg(format!("/proc/{}/exe", pid_))
+                    .output()
+                {
+                    Ok(out) => {
+                        let mut __stdout = out.stdout;
+                        if !__stdout.is_empty() {
+                            __stdout.pop();
+                        }
+                        let exec_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
+                        Some(exec_)
+                    }
+                    Err(_) => None,
+                }
             }
             Err(_) => None,
         };

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -26,7 +26,7 @@ pub(crate) struct WaylandAppInfoProvider {}
 fn empty_app_info() -> AppInfo {
     AppInfo {
         title: None,
-        exec: Some("Maybe missing kdotool?".into()),
+        exec: Some("Missing kdotool or non-KDE environment!".into()),
         class: None,
     }
 }
@@ -65,7 +65,27 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             Err(_) => None,
         };
 
-        let exec = Some("maybe have kdotool?".into());
+        let exec = match Command::new("kdotool")
+            .arg("getactivewindow")
+            .arg("getwindowpid")
+            .output()
+        {
+            Ok(out) => {
+                let pid_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                match Command::new("readlink")
+                    .arg(format!("/proc/{}", pid_))
+                    .output()
+                {
+                    Ok(out) => {
+                        let exec_ =
+                            String::from_utf8(out.stdout).expect("Error decoding from utf8");
+                        Some(exec_)
+                    }
+                    Err(_) => None,
+                }
+            }
+            Err(_) => None,
+        };
 
         AppInfo { title, exec, class }
     }

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -73,7 +73,7 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             Ok(out) => {
                 let pid_ = String::from_utf8(out.stdout).expect("Error decoding from utf8");
                 match Command::new("readlink")
-                    .arg(format!("/proc/{}", pid_))
+                    .arg(format!("/proc/{}/exe", pid_))
                     .output()
                 {
                     Ok(out) => {

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -26,7 +26,7 @@ pub(crate) struct WaylandAppInfoProvider {}
 fn empty_app_info() -> AppInfo {
     AppInfo {
         title: None,
-        exec: Some("Missing kdotool or non-KDE environment!".into()),
+        exec: Some("Missing kdotool!".into()),
         class: None,
     }
 }


### PR DESCRIPTION
Uses [kdotool](https://github.com/jinliu/kdotool) to get window title, class, and exec, allowing to use app-specific filters on Wayland