### PR TITLE
:wrench: make biome ignore `docs/book/*`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,9 @@
     "clientKind": "git",
     "useIgnoreFile": true
   },
+  "files": {
+    "ignore": ["./docs/book/**"]
+  },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",


### PR DESCRIPTION
There is a >1mb js file inside `docs/book/*`, and biome refuses to format (it's correct).
Even the `book` sub directory is ignored in the gitignore, so I make an exception for biome for that folder