### PR TITLE
:mute: move the kdetool log to a startup position

### DIFF
--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -18,7 +18,6 @@
  */
 
 use crate::{AppInfo, AppInfoProvider};
-use espanso_package::info_println;
 
 use std::process::Command;
 
@@ -54,7 +53,8 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
             Some(class_)
         } else {
-            info_println!("kdotool missing or not available for the current wayland DE.");
+            // kdotool is checked once in the startup of main.rs
+            // we do not need to log it here again
             return empty_app_info();
         };
 

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -20,7 +20,7 @@
 // This is needed to avoid showing a console window when starting espanso on Windows
 #![windows_subsystem = "windows"]
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::Command};
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use cli::{CliAlias, CliModule, CliModuleArgs};
@@ -611,6 +611,17 @@ For example, specifying 'email' is equivalent to 'match/email.yml'."#))
             }
 
             cli_args.paths = Some(paths);
+        }
+
+        // try to invoke `kdotool` to see if you have it or not.
+        if Command::new("kdotool")
+            .arg("getactivewindow")
+            .arg("getwindowclassname")
+            .output()
+            .is_ok()
+        {
+        } else {
+            info!("kdotool missing or not available for the current wayland DE.");
         }
 
         // If the current handler is an alias, rather than sending the sub-arguments


### PR DESCRIPTION
fixes #2366 

I moved the log into `main.rs`. It just run once every time the main.rs is invoked.
Should reduce the input significantly, but I still have some doubts if it's only once per excecution