### PR TITLE
Add support for Niri wayland compositor

### DIFF
--- a/espanso-info/src/lib.rs
+++ b/espanso-info/src/lib.rs
@@ -31,10 +31,6 @@ mod x11;
 #[cfg(feature = "wayland")]
 mod wayland;
 
-#[cfg(target_os = "linux")]
-#[cfg(feature = "wayland")]
-use std::env;
-
 #[cfg(target_os = "macos")]
 mod cocoa;
 
@@ -72,6 +68,8 @@ pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
 #[cfg(feature = "wayland")]
 #[allow(clippy::match_str_case_mismatch)]
 pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
+    use std::env;
+
     if let Ok(value) = env::var("XDG_SESSION_DESKTOP") {
         match value.to_lowercase().as_str() {
             "niri" => {
@@ -79,8 +77,19 @@ pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
                 return Ok(Box::new(wayland::WaylandNiriAppInfoProvider::new()));
             }
             "kde" => {
-                info!("using WaylandKDEAppInfoProvider");
-                return Ok(Box::new(wayland::WaylandKDEAppInfoProvider::new()));
+                // try to invoke `kdotool` to see if you have it or not.
+                use std::process::Command;
+                if Command::new("kdotool")
+                    .arg("getactivewindow")
+                    .arg("getwindowclassname")
+                    .output()
+                    .is_ok()
+                {
+                    info!("using WaylandKDEAppInfoProvider");
+                    return Ok(Box::new(wayland::WaylandKDEAppInfoProvider::new()));
+                }
+                info!("kdotool missing or not available for the current wayland DE.");
+                // since we dont have `kdotool` anyway, just output empty info
             }
             _ => {}
         }

--- a/espanso-info/src/lib.rs
+++ b/espanso-info/src/lib.rs
@@ -19,6 +19,7 @@
 
 use anyhow::Result;
 use log::info;
+use std::env;
 
 #[cfg(target_os = "windows")]
 mod win32;
@@ -66,9 +67,24 @@ pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
 
 #[cfg(target_os = "linux")]
 #[cfg(feature = "wayland")]
+#[allow(clippy::match_str_case_mismatch)]
 pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
-    info!("using WaylandAppInfoProvider");
-    Ok(Box::new(wayland::WaylandAppInfoProvider::new()))
+    if let Ok(value) = env::var("XDG_SESSION_DESKTOP") {
+        match value.to_lowercase().as_str() {
+            "niri" => {
+                info!("using WaylandNiriAppInfoProvider");
+                return Ok(Box::new(wayland::WaylandNiriAppInfoProvider::new()));
+            }
+            "KDE" => {
+                info!("using WaylandKDEAppInfoProvider");
+                return Ok(Box::new(wayland::WaylandKDEAppInfoProvider::new()));
+            }
+            _ => {}
+        }
+    }
+
+    info!("no appropriate WaylandAppInfoProvider found for current DE/WM");
+    Ok(Box::new(wayland::WaylandEmptyAppInfoProvider::new()))
 }
 
 #[cfg(target_os = "windows")]

--- a/espanso-info/src/lib.rs
+++ b/espanso-info/src/lib.rs
@@ -78,7 +78,7 @@ pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
                 info!("using WaylandNiriAppInfoProvider");
                 return Ok(Box::new(wayland::WaylandNiriAppInfoProvider::new()));
             }
-            "KDE" => {
+            "kde" => {
                 info!("using WaylandKDEAppInfoProvider");
                 return Ok(Box::new(wayland::WaylandKDEAppInfoProvider::new()));
             }

--- a/espanso-info/src/lib.rs
+++ b/espanso-info/src/lib.rs
@@ -19,7 +19,6 @@
 
 use anyhow::Result;
 use log::info;
-use std::env;
 
 #[cfg(target_os = "windows")]
 mod win32;
@@ -31,6 +30,10 @@ mod x11;
 #[cfg(target_os = "linux")]
 #[cfg(feature = "wayland")]
 mod wayland;
+
+#[cfg(target_os = "linux")]
+#[cfg(feature = "wayland")]
+use std::env;
 
 #[cfg(target_os = "macos")]
 mod cocoa;

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -18,7 +18,6 @@
  */
 
 use crate::{AppInfo, AppInfoProvider};
-use espanso_package::info_println;
 
 use std::process::Command;
 
@@ -54,7 +53,8 @@ impl AppInfoProvider for WaylandAppInfoProvider {
             let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
             Some(class_)
         } else {
-            info_println!("kdotool missing or not available for the current wayland DE.");
+            // kdotool is checked once in the startup of main.rs
+            // we do not need to log it here again
             return empty_app_info();
         };
 

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -21,6 +21,7 @@ use crate::{AppInfo, AppInfoProvider};
 
 use std::process::Command;
 
+pub(crate) struct WaylandEmptyInfoProvider {}
 pub(crate) struct WaylandKDEAppInfoProvider {}
 
 fn empty_app_info() -> AppInfo {
@@ -31,6 +32,20 @@ fn empty_app_info() -> AppInfo {
     }
 }
 
+// for unsupported DEs/WMs
+impl WaylandEmptyInfoProvider {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl AppInfoProvider for WaylandEmptyInfoProvider {
+    fn get_info(&self) -> AppInfo {
+        empty_app_info()
+    }
+}
+
+// for KDE with kdotool
 impl WaylandKDEAppInfoProvider {
     pub fn new() -> Self {
         Self {}
@@ -38,7 +53,6 @@ impl WaylandKDEAppInfoProvider {
 }
 
 impl AppInfoProvider for WaylandKDEAppInfoProvider {
-    // TODO: other get current window info for other window managers
     fn get_info(&self) -> AppInfo {
         let class = if let Ok(out) = Command::new("kdotool")
             .arg("getactivewindow")

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -38,8 +38,7 @@ impl WaylandAppInfoProvider {
 }
 
 impl AppInfoProvider for WaylandAppInfoProvider {
-    // TODO: can we read these info on Wayland?
-    // maybe
+    // TODO: other get current window info for other window managers
     fn get_info(&self) -> AppInfo {
         let class = if let Ok(out) = Command::new("kdotool")
             .arg("getactivewindow")

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -21,7 +21,7 @@ use crate::{AppInfo, AppInfoProvider};
 
 use std::process::Command;
 
-pub(crate) struct WaylandEmptyInfoProvider {}
+pub(crate) struct WaylandEmptyAppInfoProvider {}
 pub(crate) struct WaylandKDEAppInfoProvider {}
 
 fn empty_app_info() -> AppInfo {
@@ -33,13 +33,13 @@ fn empty_app_info() -> AppInfo {
 }
 
 // for unsupported DEs/WMs
-impl WaylandEmptyInfoProvider {
+impl WaylandEmptyAppInfoProvider {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl AppInfoProvider for WaylandEmptyInfoProvider {
+impl AppInfoProvider for WaylandEmptyAppInfoProvider {
     fn get_info(&self) -> AppInfo {
         empty_app_info()
     }

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -135,14 +135,37 @@ impl AppInfoProvider for WaylandNiriAppInfoProvider {
             .arg("focused-window")
             .output()
         {
-            let mut __stdout = out.stdout;
-            // if !__stdout.is_empty() {
-            //     __stdout.pop();
-            // }
+            let txt = String::from_utf8(out.stdout).expect("Error decoding from utf8");
 
-            let title = Some(String::from_utf8(__stdout).expect("some error"));
-            let exec = None;
-            let class = None;
+            let mut title = None;
+            let mut class = None;
+            let mut exec = None;
+
+            for line in txt.lines() {
+                let trimmed = line.trim();
+                if let Some(rest) = trimmed.strip_prefix("Title:") {
+                    title = Some(rest.trim().trim_matches('"').to_string());
+                } else if let Some(rest) = trimmed.strip_prefix("App ID:") {
+                    class = Some(rest.trim().trim_matches('"').to_string());
+                } else if let Some(rest) = trimmed.strip_prefix("PID:") {
+                    let pid_ = rest.trim().to_string();
+                    exec = match Command::new("readlink")
+                        .arg(format!("/proc/{pid_}/exe"))
+                        .output()
+                    {
+                        Ok(out) => {
+                            let mut __stdout = out.stdout;
+                            if !__stdout.is_empty() {
+                                __stdout.pop();
+                            }
+                            let exec_ =
+                                String::from_utf8(__stdout).expect("Error decoding from utf8");
+                            Some(exec_)
+                        }
+                        Err(_) => None,
+                    }
+                }
+            }
 
             return AppInfo { title, exec, class };
         }

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -21,7 +21,7 @@ use crate::{AppInfo, AppInfoProvider};
 
 use std::process::Command;
 
-pub(crate) struct WaylandAppInfoProvider {}
+pub(crate) struct WaylandKDEAppInfoProvider {}
 
 fn empty_app_info() -> AppInfo {
     AppInfo {
@@ -31,13 +31,13 @@ fn empty_app_info() -> AppInfo {
     }
 }
 
-impl WaylandAppInfoProvider {
+impl WaylandKDEAppInfoProvider {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl AppInfoProvider for WaylandAppInfoProvider {
+impl AppInfoProvider for WaylandKDEAppInfoProvider {
     // TODO: other get current window info for other window managers
     fn get_info(&self) -> AppInfo {
         let class = if let Ok(out) = Command::new("kdotool")

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -23,6 +23,7 @@ use std::process::Command;
 
 pub(crate) struct WaylandEmptyAppInfoProvider {}
 pub(crate) struct WaylandKDEAppInfoProvider {}
+pub(crate) struct WaylandNiriAppInfoProvider {}
 
 fn empty_app_info() -> AppInfo {
     AppInfo {
@@ -117,5 +118,34 @@ impl AppInfoProvider for WaylandKDEAppInfoProvider {
         };
 
         AppInfo { title, exec, class }
+    }
+}
+
+// for Niri
+impl WaylandNiriAppInfoProvider {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl AppInfoProvider for WaylandNiriAppInfoProvider {
+    fn get_info(&self) -> AppInfo {
+        if let Ok(out) = Command::new("niri")
+            .arg("msg")
+            .arg("focused-window")
+            .output()
+        {
+            let mut __stdout = out.stdout;
+            // if !__stdout.is_empty() {
+            //     __stdout.pop();
+            // }
+
+            let title = Some(String::from_utf8(__stdout).expect("some error"));
+            let exec = None;
+            let class = None;
+
+            return AppInfo { title, exec, class };
+        }
+        empty_app_info()
     }
 }

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -20,7 +20,7 @@
 // This is needed to avoid showing a console window when starting espanso on Windows
 #![windows_subsystem = "windows"]
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::Command};
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use cli::{CliAlias, CliModule, CliModuleArgs};
@@ -611,6 +611,17 @@ For example, specifying 'email' is equivalent to 'match/email.yml'."#))
             }
 
             cli_args.paths = Some(paths);
+        }
+
+        // try to invoke `kdotool` to see if you have it or not.
+        if Command::new("kdotool")
+            .arg("getactivewindow")
+            .arg("getwindowclassname")
+            .output()
+            .is_ok()
+        {
+        } else {
+            info!("kdotool missing or not available for the current wayland DE.");
         }
 
         // If the current handler is an alias, rather than sending the sub-arguments

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -20,7 +20,7 @@
 // This is needed to avoid showing a console window when starting espanso on Windows
 #![windows_subsystem = "windows"]
 
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use cli::{CliAlias, CliModule, CliModuleArgs};
@@ -246,9 +246,9 @@ fn main() {
     .subcommand(SubCommand::with_name("edit")
         .about("Shortcut to open the default text editor to edit config files")
         .arg(Arg::with_name("target_file")
-            .help(r#"Defaults to "match/base.yml", it contains the relative path of the file you want to edit, 
-such as 'config/default.yml' or 'match/base.yml'. 
-For convenience, you can also specify the name directly and Espanso will figure out the path. 
+            .help(r#"Defaults to "match/base.yml", it contains the relative path of the file you want to edit,
+such as 'config/default.yml' or 'match/base.yml'.
+For convenience, you can also specify the name directly and Espanso will figure out the path.
 For example, specifying 'email' is equivalent to 'match/email.yml'."#))
         // .arg(Arg::with_name("norestart")
         //     .short("n")
@@ -611,17 +611,6 @@ For example, specifying 'email' is equivalent to 'match/email.yml'."#))
             }
 
             cli_args.paths = Some(paths);
-        }
-
-        // try to invoke `kdotool` to see if you have it or not.
-        if Command::new("kdotool")
-            .arg("getactivewindow")
-            .arg("getwindowclassname")
-            .output()
-            .is_ok()
-        {
-        } else {
-            info!("kdotool missing or not available for the current wayland DE.");
         }
 
         // If the current handler is an alias, rather than sending the sub-arguments


### PR DESCRIPTION
Checks the XDG_SESSION_DESKTOP to get the appropriate provider between KDE and niri. 