### PR TITLE
:hammer: remove the symlink before creating a new one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "espanso"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "anyhow",
  "caps",

--- a/espanso/src/path/linux.rs
+++ b/espanso/src/path/linux.rs
@@ -18,6 +18,7 @@
  */
 
 use anyhow::Result;
+use log::debug;
 use std::path::PathBuf;
 use thiserror::Error;
 

--- a/espanso/src/path/linux.rs
+++ b/espanso/src/path/linux.rs
@@ -35,7 +35,13 @@ pub fn add_espanso_to_path(_: bool) -> Result<()> {
 
     let target_link_path = target_link_dir.join("espanso");
 
+    if target_link_path.exists() && target_link_path.is_symlink() {
+        debug!("the symlink already exist, removing...");
+        remove_espanso_from_path(true)?;
+    }
+
     if let Err(error) = std::os::unix::fs::symlink(exec_path, target_link_path) {
+        debug!("creating the symlink from executable to /usr/local/bin");
         return Err(PathError::SymlinkError(error).into());
     }
 

--- a/espanso/src/path/macos.rs
+++ b/espanso/src/path/macos.rs
@@ -22,7 +22,7 @@ use std::{fs::create_dir_all, io::ErrorKind};
 use thiserror::Error;
 
 use anyhow::{bail, Context, Result};
-use log::{error, warn};
+use log::{debug, error, warn};
 
 pub fn is_espanso_in_path() -> bool {
     PathBuf::from("/usr/local/bin/espanso").is_file()
@@ -62,7 +62,13 @@ pub fn add_espanso_to_path(prompt_when_necessary: bool) -> Result<()> {
         }
     }
 
+    if target_link_path.exists() && target_link_path.is_symlink() {
+        debug!("the symlink already exist, removing...");
+        remove_espanso_from_path(true)?;
+    }
+
     if let Err(error) = std::os::unix::fs::symlink(&exec_path, &target_link_path) {
+        debug!("creating the symlink from executable to /usr/local/bin");
         match error.kind() {
             ErrorKind::PermissionDenied if prompt_when_necessary => {
                 warn!("target link file can't be accessed with current permissions, requesting elevated ones through AppleScript.");


### PR DESCRIPTION
When you
```
sudo ./Espanso.AppImage env-path register
```

it errors with
```
Unable to add 'espanso' command to PATH: symlink error: `File exists (os error 17)`
```

That is because the link exists, and espanso never checks if it exists before creating one. So I added some lines to remove it if it founds one before creating a different one

[link to the discord issue](https://discord.com/channels/884163483409731584/1395011451835383920)