### PR TITLE
:adhesive_bandage: ignore some binaries and edit `ci` workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   push:
     paths-ignore:
       - 'docs/**'
-    branches:
-      - master
-      - dev
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,13 @@ venv/
 Espanso-Win-Installer-x86_64*
 Espanso-Win-Portable-x86_64*
 
+# macOS
+*.dmg
+
+# Linux
+*.deb
+*.AppImage
+
 # rust
 mutants.out*
 tarpaulin-report.html


### PR DESCRIPTION
- Added
```
# macOS
*.dmg

# Linux
*.deb
*.AppImage
```
to the .gitignore, and

- Removed the CI workflow when the PR is merged to dev (we already have the `dev-release` workflow which does the same)