### PR TITLE
:construction_worker: update the names of the artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: upload-unsigned-artifact
         with:
-          name: Linux X11 Artifacts
+          name: Linux X11 AppImage Artifact
           path: |
             Espanso-X11.AppImage
       - name: Upload artifacts to Github Releases
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: upload-unsigned-artifact
         with:
-          name: Ubuntu-Debian Artifacts
+          name: Linux Deb Artifacts
           path: |
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb
@@ -228,25 +228,3 @@ jobs:
       - name: Upload artifacts to Github Releases
         run: |
           gh release upload ${{ needs.extract-version.outputs.espanso_version }} Espanso-Mac-Universal.zip
-
-  macos-publish-homebrew:
-    needs: ["extract-version", "create-release", "macos"]
-    runs-on: macos-latest
-    continue-on-error: false
-
-    steps:
-      - uses: actions/checkout@main
-      - name: Print target version
-        run: |
-          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
-
-      - name: "Setup SSH deploy key"
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd
-        with:
-          ssh-private-key: ${{ secrets.HOMEBREW_CASK_SSH_PRIVATE_KEY }}
-
-      - name: Create and Publish Homebrew Cask
-        run: |
-          VERSION="${{ needs.extract-version.outputs.espanso_version }}" ./scripts/publish_homebrew_version.sh
-
-          echo "Cask formula has been published here: "

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: "Upload artifacts"
         with:
-          name: Linux X11 Artifacts
+          name: Linux X11 AppImage Artifact
           path: |
             Espanso-X11.AppImage
 
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: "Upload artifacts"
         with:
-          name: Ubuntu-Debian Artifacts
+          name: Linux Deb Artifacts
           path: |
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb

--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ venv/
 
 # Binaries
 
-# Debian package builds
-*.deb
-
 # Windows
 Espanso-Win-Installer-x86_64*
 Espanso-Win-Portable-x86_64*


### PR DESCRIPTION
A better name convention, from:

- `Linux X11 Artifacts` to `Linux X11 AppImage Artifact`
- `Ubuntu-Debian Artifacts` to `Linux Deb Artifacts`

And also deleting the step of the homebrew, given we are not using espanso-homebrew custom cask anymore
