### PR TITLE
Fix windows installer location zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           name: Windows Artifacts
           path: |
-            target/windows/installer/Espanso-Win-Installer-x86_64.exe
+            target/windows/Espanso-Win-Installer-x86_64.exe
             target/windows/Espanso-Win-Portable-x86_64.zip
       - id: sign-windows-release
         uses: signpath/github-action-submit-signing-request@v1

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: upload-unsigned-artifact
         with:
-          name: Linux X11 Artifacts
+          name: Linux X11 AppImage Artifact
           path: |
             Espanso-X11.AppImage
       - name: Upload artifacts to Github Releases
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: upload-unsigned-artifact
         with:
-          name: Ubuntu-Debian Artifacts
+          name: Linux Deb Artifacts
           path: |
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb
@@ -228,25 +228,3 @@ jobs:
       - name: Upload artifacts to Github Releases
         run: |
           gh release upload ${{ needs.extract-version.outputs.espanso_version }} Espanso-Mac-Universal.zip
-
-  macos-publish-homebrew:
-    needs: ["extract-version", "create-release", "macos"]
-    runs-on: macos-latest
-    continue-on-error: false
-
-    steps:
-      - uses: actions/checkout@main
-      - name: Print target version
-        run: |
-          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
-
-      - name: "Setup SSH deploy key"
-        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd
-        with:
-          ssh-private-key: ${{ secrets.HOMEBREW_CASK_SSH_PRIVATE_KEY }}
-
-      - name: Create and Publish Homebrew Cask
-        run: |
-          VERSION="${{ needs.extract-version.outputs.espanso_version }}" ./scripts/publish_homebrew_version.sh
-
-          echo "Cask formula has been published here: "

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           name: Windows Artifacts
           path: |
-            target/windows/installer/Espanso-Win-Installer-x86_64.exe
+            target/windows/Espanso-Win-Installer-x86_64.exe
             target/windows/Espanso-Win-Portable-x86_64.zip
 
   linux-x11:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: "Upload artifacts"
         with:
-          name: Linux X11 Artifacts
+          name: Linux X11 AppImage Artifact
           path: |
             Espanso-X11.AppImage
 
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/upload-artifact@main
         name: "Upload artifacts"
         with:
-          name: Ubuntu-Debian Artifacts
+          name: Linux Deb Artifacts
           path: |
             espanso-debian-x11-amd64.deb
             espanso-debian-wayland-amd64.deb

--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ venv/
 
 # Binaries
 
-# Debian package builds
-*.deb
-
 # Windows
 Espanso-Win-Installer-x86_64*
 Espanso-Win-Portable-x86_64*

--- a/docs/src/ch03-01-windows.md
+++ b/docs/src/ch03-01-windows.md
@@ -41,7 +41,7 @@ Install-Module -Name 'PSTOML' -Force # just needed once
 scripts\build_windows_installer.ps1
 ```
 
-This will generate the installer in the `target/windows/installer` directory.
+This will generate the installer in the `target/windows` directory.
 
 ##### Portable mode bundle
 
@@ -53,5 +53,5 @@ then running:
 scripts\build_windows_portable.ps1
 ```
 
-This will generate the executable in the `target/windows/portable` directory.
+This will generate the zip file in the `target/windows` directory.
 There are README instructions inside!.

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -9,7 +9,6 @@ $ErrorActionPreference = "Stop"
 # Define constants
 $INSTALLER_NAME = "Espanso-Win-Installer"
 $ARCH = "x86_64"
-$TARGET_DIR = "target/windows/installer"
 $RESOURCE_DIR = "target/windows/resources"
 
 $BASE_DIR = Get-Location
@@ -33,7 +32,6 @@ function Get-TomlVersion {
     }
 
     Write-Error "Could not find the version in Cargo.toml"
-
 }
 
 function Main {
@@ -42,14 +40,6 @@ function Main {
     if (!$espansod_exists) {
         Write-Error "You need to build the windows resources first.`nPlease run scripts/build_windows_resources.ps1"
     }
-
-    # Clean the output directory
-    if (Test-Path $TARGET_DIR) {
-        Remove-Item $TARGET_DIR -Recurse -Force
-    }
-
-    # Create the target directory
-    New-Item -Path $TARGET_DIR -ItemType Directory -Force | Out-Null
 
     $script_resources_path = Join-Path $BASE_DIR "scripts/resources/windows"
     $template_path = Join-Path $script_resources_path "setupscript.iss"
@@ -67,7 +57,7 @@ function Main {
     $license = Join-Path $BASE_DIR "LICENSE"
     $icon = Join-Path $script_resources_path "icon.ico"
     $cli_helper = Join-Path $script_resources_path "espanso.cmd"
-    $output_dir = Join-Path $BASE_DIR $TARGET_DIR
+    $output_dir = Join-Path $BASE_DIR "target/windows"
 
     $include_paths = ""
     Get-ChildItem -Path $RESOURCE_DIR -Filter "*.dll" | ForEach-Object {
@@ -85,7 +75,7 @@ function Main {
     $template = $template -replace '{{{executable_path}}}', $espansod_path
     $template = $template -replace '{{{dll_include}}}', $include_paths
 
-    $iss_setup = Join-Path $TARGET_DIR "setupscript.iss"
+    $iss_setup = Join-Path $RESOURCE_DIR "setupscript.iss"
     $template | Out-File $iss_setup -Encoding UTF8
 
     # Helpful for debugging in CI, as the iscc errors mention line numbers


### PR DESCRIPTION
Changed:
`target/windows/installer/Espanso-Win-Installer-x86_64.exe`
for
`target/windows/Espanso-Win-Installer-x86_64.exe`

So SignPath can find the executables to certificate them 👌