### PR TITLE
:bug: fix missing rust in windows arm runner

### DIFF
--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@main
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       #   - name: Format
       #     run: cargo fmt --all -- --check
       - name: Build


### PR DESCRIPTION
missing a
```
      - uses: actions-rust-lang/setup-rust-toolchain@v1
```