### PR TITLE
Post installation script for setting capabilities

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -318,6 +318,57 @@
             ]
         },
         {
+            "label": "Build .deb package",
+            "detail": "Builds the deb package. It needs cargo-deb and a Debian based distro",
+            "type": "cargo",
+            "problemMatcher": [],
+            "command": "deb",
+            "args": [
+                "-p",
+                "espanso",
+                "--variant",
+                "wayland",
+                "--",
+                "--no-default-features",
+                "--features",
+                "modulo wayland vendored-tls"
+            ]
+        },
+        {
+            "label": "Build .deb - Docker image",
+            "detail": "Prepare the Docker image build the .deb file",
+            "type": "shell",
+            "problemMatcher": [],
+            "command": "sudo",
+            "args": [
+                "docker",
+                "build",
+                "-t",
+                "espanso-ubuntu",
+                ".",
+                "-f",
+                ".github/scripts/Dockerfile"
+            ]
+        },
+        {
+            "label": "Build .deb - Docker deb build",
+            "detail": "Build the .deb file from the Docker image",
+            "type": "shell",
+            "problemMatcher": [],
+            "command": "sudo",
+            "args": [
+                "docker",
+                "run",
+                "-v",
+                "\"$(pwd):/shared\"",
+                "espanso-ubuntu",
+                "espanso/.github/scripts/ubuntu/build_deb.sh",
+            ],
+            "dependsOn": [
+                "Build .deb - Docker image"
+            ]
+        },
+        {
             "label": "Build everything: linux",
             "detail": "excecutable, AppImage, deb package",
             "dependsOn": [

--- a/espanso/Cargo.toml
+++ b/espanso/Cargo.toml
@@ -96,6 +96,7 @@ license-file = ["../LICENSE", "1"]
 
 [package.metadata.deb.variants.wayland]
 depends = ["wl-clipboard", "$auto"]
+maintainer-scripts = "scripts/debian/"
 
 [package.metadata.generate-rpm]
 assets = [

--- a/espanso/scripts/debian/postinst
+++ b/espanso/scripts/debian/postinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+setcap "cap_dac_override+p" $(which espanso)

--- a/flake.nix
+++ b/flake.nix
@@ -28,18 +28,17 @@
       {
         checks.espanso = self.packages.${system}.espanso.override { buildType = "debug"; };
         formatter = pkgs.nixfmt-rfc-style;
-        packages =
-          {
-            espanso = pkgs.callPackage ./nix/espanso.nix { };
-            default = self.packages.${system}.espanso;
-          }
-          // (nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-            espanso-wayland = (
-              pkgs.callPackage ./nix/espanso.nix {
-                waylandSupport = true;
-              }
-            );
-          });
+        packages = {
+          espanso = pkgs.callPackage ./nix/espanso.nix { };
+          default = self.packages.${system}.espanso;
+        }
+        // (nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          espanso-wayland = (
+            pkgs.callPackage ./nix/espanso.nix {
+              waylandSupport = true;
+            }
+          );
+        });
         devShells =
           let
             commonRustFlagsEnv = "-C target-cpu=native";

--- a/nix/espanso.nix
+++ b/nix/espanso.nix
@@ -45,27 +45,26 @@ rustPlatform.buildRustPackage {
   };
   doCheck = true;
 
-  buildInputs =
-    [
-      libpng
-      wxGTK32
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      dbus
-      libxkbcommon
-      openssl
-      setxkbmap
-    ]
-    ++ lib.optionals waylandSupport [
-      wl-clipboard
-    ]
-    ++ lib.optionals x11Support [
-      libX11
-      libXi
-      libXtst
-      xclip
-      xdotool
-    ];
+  buildInputs = [
+    libpng
+    wxGTK32
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
+    libxkbcommon
+    openssl
+    setxkbmap
+  ]
+  ++ lib.optionals waylandSupport [
+    wl-clipboard
+  ]
+  ++ lib.optionals x11Support [
+    libX11
+    libXi
+    libXtst
+    xclip
+    xdotool
+  ];
   nativeBuildInputs = [
     pkg-config
     wxGTK32
@@ -74,19 +73,18 @@ rustPlatform.buildRustPackage {
   inherit buildType;
 
   buildNoDefaultFeatures = true;
-  buildFeatures =
-    [
-      "modulo"
-    ]
-    ++ lib.optionals waylandSupport [
-      "wayland"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      "vendored-tls"
-    ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin [
-      "native-tls"
-    ];
+  buildFeatures = [
+    "modulo"
+  ]
+  ++ lib.optionals waylandSupport [
+    "wayland"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "vendored-tls"
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin [
+    "native-tls"
+  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace scripts/create_bundle.sh \


### PR DESCRIPTION
fix #2172 

This modifies the `.deb` package only on the Wayland variant.
When the package is installed, it runs a post script install that automatically runs
```
setcap "cap_dac_override+p" $(which espanso)
```

For you.

### note
It is also possible to manage systemd service files via `cargo-deb`. I was about to do it but it's significantly more effort than this, and again, only possible for the .deb package. On the AppImage you still need to run `espanso service register`. It's a small gain