### PR TITLE
Json schemas

### DIFF
--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -839,7 +839,6 @@
     "form_multiline_field": {
       "$comment": "multine string",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "multiline": {
           "type": "boolean"
@@ -853,7 +852,6 @@
     "form_choice_or_list_field": {
       "$comment": "choice or list",
       "type": "object",
-      "additionalProperties": false,
       "required": [
         "values",
         "type"

--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -45,23 +45,35 @@
       "additionalProperties": false,
       "required": [],
       "dependencies": {
-        "uppercase_style": ["propagate_case"]
+        "uppercase_style": [
+          "propagate_case"
+        ]
       },
       "oneOf": [
         {
-          "required": ["replace"]
+          "required": [
+            "replace"
+          ]
         },
         {
-          "required": ["form"]
+          "required": [
+            "form"
+          ]
         },
         {
-          "required": ["html"]
+          "required": [
+            "html"
+          ]
         },
         {
-          "required": ["image_path"]
+          "required": [
+            "image_path"
+          ]
         },
         {
-          "required": ["markdown"]
+          "required": [
+            "markdown"
+          ]
         }
       ],
       "properties": {
@@ -76,7 +88,10 @@
         },
         "force_mode": {
           "type": "string",
-          "enum": ["clipboard", "keys"]
+          "enum": [
+            "clipboard",
+            "keys"
+          ]
         },
         "form": {
           "type": "string"
@@ -117,13 +132,20 @@
         },
         "uppercase_style": {
           "type": "string",
-          "enum": ["capitalize", "capitalize_words", "uppercase"]
+          "enum": [
+            "capitalize",
+            "capitalize_words",
+            "uppercase"
+          ]
         },
         "regex": {
           "type": "string"
         },
         "replace": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "trigger": {
           "type": "string"
@@ -155,7 +177,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["shell"]
+              "enum": [
+                "shell"
+              ]
             },
             "name": {
               "type": "string"
@@ -209,7 +233,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["script"]
+              "enum": [
+                "script"
+              ]
             },
             "name": {
               "type": "string"
@@ -245,7 +271,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["date"]
+              "enum": [
+                "date"
+              ]
             },
             "name": {
               "type": "string"
@@ -587,7 +615,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["echo"]
+              "enum": [
+                "echo"
+              ]
             },
             "name": {
               "type": "string"
@@ -619,7 +649,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["clipboard"]
+              "enum": [
+                "clipboard"
+              ]
             },
             "name": {
               "type": "string"
@@ -642,7 +674,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["choice"]
+              "enum": [
+                "choice"
+              ]
             },
             "name": {
               "type": "string"
@@ -654,7 +688,10 @@
                 "values": {
                   "type": "array",
                   "items": {
-                    "required": ["label", "id"],
+                    "required": [
+                      "label",
+                      "id"
+                    ],
                     "properties": {
                       "label": {
                         "type": "string"
@@ -685,7 +722,9 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["form"]
+              "enum": [
+                "form"
+              ]
             },
             "name": {
               "type": "string"
@@ -714,13 +753,43 @@
           }
         },
         {
+          "$comment": "random",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "random"
+              ]
+            },
+            "params": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "choice": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
           "$comment": "Nested match",
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["match"]
+              "enum": [
+                "match"
+              ]
             },
             "name": {
               "type": "string"
@@ -785,14 +854,23 @@
       "$comment": "choice or list",
       "type": "object",
       "additionalProperties": false,
-      "required": ["values", "type"],
+      "required": [
+        "values",
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["choice", "list"]
+          "enum": [
+            "choice",
+            "list"
+          ]
         },
         "values": {
-          "type": ["array", "string"],
+          "type": [
+            "array",
+            "string"
+          ],
           "items": {
             "type": "string"
           }

--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -109,6 +109,7 @@
           "type": "string"
         },
         "left_word": {
+          "description": "The related properties, left_word: true and right_word: true, ensure a match will only occur at the beginning or end of words respectively, and not in the middle.",
           "type": "boolean"
         },
         "markdown": {
@@ -122,6 +123,7 @@
           "type": "boolean"
         },
         "right_word": {
+          "description": "The related properties, left_word: true and right_word: true, ensure a match will only occur at the beginning or end of words respectively, and not in the middle.",
           "type": "boolean"
         },
         "search_terms": {
@@ -174,6 +176,10 @@
           "$comment": "shell var",
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "type",
+            "name"
+          ],
           "properties": {
             "type": {
               "type": "string",

--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -776,7 +776,7 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "choice": {
+                "choices": {
                   "type": "array",
                   "items": {
                     "type": "string"


### PR DESCRIPTION
fixes #2122 
I have a couple of topics to talk:

# First question

> anchors: and anchor: are arbitrary names but worth including as such. anchors: need not be unique if you have any control over that.

Mmmm, the main top-level keys are:
- $schema
- imports
- anchors
- match
- global_vars

I don't allow any other top level key. Is that alright? (I saw you ask in the body of the #2122 issue)

# Segunda pregunta:

```yaml
  - trigger: something
    replace: null # "Incorrect type. Expected "string".
```
causes this popup
<img width="820" height="537" alt="image" src="https://github.com/user-attachments/assets/3d5751bc-2786-431e-9030-3e056babcf05" />

Is that your intended action? 🤔

# Finally

This schema should work for this collection of samples:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/espanso/espanso/refs/heads/json-schemas/schemas/match.schema.json

imports:
  - "python.yml"

anchors:
  - &script1 |
    fruits = "apple"

global_vars:
  - name: one
    type: shell
    params:
      cmd: "echo one"
  - name: two
    type: shell
    depends_on: ["one"]
    params:
      cmd: "echo two"

matches:
  - trigger: ":localip"
    replace: "{{output}}"
    vars:
      - name: output
        type: shell
        params:
          cmd: "ip a"
          trim: false

  - trigger: :test
    replace: "{{output}}"
    anchor: &script1 |
      fruits = "banana"

  - trigger: \ao3ip
    form: "Currently @ Chapter [[chapnum]] (In Progress)"
    form_fields:
      chapnum: # "Property chapnum is not allowed"
        default: "1"

  - trigger: something
    # comment out because it errors
    # replace: null # "Incorrect type. Expected "string".
    replace: something

  - trigger: ":localip"
    replace: "{{output}}"
    vars:
      - name: output
        type: shell
        params:
          shell: pwsh

  - trigger: ":localip"
    replace: "{{output}}"
    vars:
      - name: output
        type: shell
        params:
          shell: zsh

  - trigger: right_word
    replace: right_word
    right_word: true
    left_word: false

  - trigger: inject var name
    replace: hello {{output}}
    vars:
      - name: output
        inject_vars: false
        type: date

  - trigger: :meat
    replace: 🥩
    search_terms:
      - steak
      - t-bone

  - trigger: ":hello"
    comment: this is a sample from a comment key
    replace: "hello {{one}} {{two}}"

  - trigger: ":form"
    replace: "Hey {{form1.name}}, how are you? Do you like {{form1.fruit}}?"
    vars:
      - name: "form1"
        type: form
        params:
          layout: "Name: [[name]] \nFruit: [[frutas]], [[verduras]]"
          fields:
            name:
              multiline: true
            frutas:
              type: list # or `choice`
              values:
                - Apples
                - Bananas
                - Oranges
                - Peaches
            verduras:
              type: choice
              values: |
                eggplants # 🤮 I hate eggplants
                tomatoes
                lettuce

  - trigger: filename
    replace: "{{output}}"
    vars:
      - type: shell
        name: output
        params:
          cmd: |
            FILENAME="${ESPANSO_FILEPICKER_FILE%.*}"
            echo "$FILENAME"
          # debug key possible
          debug: true

  - trigger: asdfg
    replace: asdfb
    vars:
      - name: out
        type: random
        params:
          choices:
            - some text
            - different text
```

