### PR TITLE
:fire: remove the `dummy` extension

### DIFF
--- a/espanso-render/src/extension/echo.rs
+++ b/espanso-render/src/extension/echo.rs
@@ -32,6 +32,12 @@ impl EchoExtension {
     }
 }
 
+impl Default for EchoExtension {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Extension for EchoExtension {
     fn name(&self) -> &str {
         self.alias.as_str()

--- a/espanso-render/src/extension/echo.rs
+++ b/espanso-render/src/extension/echo.rs
@@ -24,17 +24,10 @@ pub struct EchoExtension {
     alias: String,
 }
 
-#[allow(clippy::new_without_default)]
 impl EchoExtension {
     pub fn new() -> Self {
         Self {
             alias: "echo".to_string(),
-        }
-    }
-
-    pub fn new_with_alias(alias: &str) -> Self {
-        Self {
-            alias: alias.to_string(),
         }
     }
 }
@@ -95,14 +88,5 @@ mod tests {
             extension.calculate(&crate::Context::default(), &HashMap::default(), &param),
             ExtensionResult::Error(_)
         ));
-    }
-
-    #[test]
-    fn alias() {
-        let extension_with_alias = EchoExtension::new_with_alias("dummy");
-        let extension = EchoExtension::new();
-
-        assert_eq!(extension.name(), "echo");
-        assert_eq!(extension_with_alias.name(), "dummy");
     }
 }

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -199,9 +199,6 @@ pub fn initialize_and_spawn(
             let date_extension =
                 espanso_render::extension::date::DateExtension::new(&locale_provider);
             let echo_extension = espanso_render::extension::echo::EchoExtension::new();
-            // For backwards compatiblity purposes, the echo extension can also be called with "dummy" type
-            let dummy_extension =
-                espanso_render::extension::echo::EchoExtension::new_with_alias("dummy");
             let random_extension = espanso_render::extension::random::RandomExtension::new();
             let home_path = dirs::home_dir().expect("unable to obtain home dir path");
             let script_extension = espanso_render::extension::script::ScriptExtension::new(
@@ -220,7 +217,6 @@ pub fn initialize_and_spawn(
                 &clipboard_extension,
                 &date_extension,
                 &echo_extension,
-                &dummy_extension,
                 &random_extension,
                 &script_extension,
                 &shell_extension,


### PR DESCRIPTION
The Dummy extension was an original extension from espanso v1, and it got renamed to echo.
We kept the `dummy` keyword just for backwards compatibility purpose.

Given so long has passed since v1, and also a lot of parts of `espanso-migrate` were removed, it's reasonable to remove the unused code.