### PR TITLE
Change panic to warning for console attachment error (fix #2464)

### DIFF
--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -24,7 +24,7 @@ use std::{path::PathBuf, process::Command};
 
 use clap::{App, AppSettings, Arg, ArgMatches, ErrorKind, SubCommand};
 use cli::{CliModule, CliModuleArgs};
-use log::{error, info};
+use log::{error, info, warn};
 use logging::FileProxy;
 use simplelog::{
     CombinedLogger, ConfigBuilder, LevelFilter, SharedLogger, TermLogger, TerminalMode, WriteLogger,
@@ -77,7 +77,7 @@ static CLI_HANDLERS: LazyLock<Vec<CliModule>> = LazyLock::new(|| {
 fn main() {
     match util::attach_console() {
         Ok(()) => info!("Console attached"),
-        Err(e) => panic!("Could not attach console! {e}"),
+        Err(e) => warn!("Could not attach console! {e}"),
     }
 
     let args: Vec<String> = std::env::args().collect();


### PR DESCRIPTION
This pull request addresses #2464 Cannot start espanso in background on Windows 11.

Previously, espanso/src/main.rs would panic and exit if attach_console() failed (e.g., when started without a terminal window). This caused espanso to silently terminate on Windows 10/11 when launched via Start Menu, startup link, or background service.

**Changes**

- Replaced `panic` on console attach failure with a non-fatal warning.
- Imported the `warn!` macro from the logging crate to support this change.

Now, if no console is available, espanso continues execution and logs a warning instead of aborting.

**Issue fixed**

Closes #2464