### PR TITLE
:sparkles: add rust-toolchain step

### DIFF
--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@main
+      - uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
       #   - name: Format
       #     run: cargo fmt --all -- --check
       - name: Install Linux X11 dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - ".devcontainer/**"
       - ".dockerignore"
       - ".editorconfig"
-      - ".github/*"
       - ".github/workflows/nix-build.yml"
       - ".github/workflows/update-flake.yml"
       - ".vscode/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
       - "images/**"
       - "schemas/**"
       - "tarpaulin.toml"
-      
+
 defaults:
   run:
     shell: bash
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
       - name: Format
         run: cargo fmt --all -- --check
       - name: Install Linux X11 dependencies
@@ -75,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
       - name: Format
         run: cargo fmt --all -- --check
       - name: Install Linux wayland dependencies
@@ -113,10 +117,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@main
-      - name: Install target
-        run: |
-          rustup update
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+      - uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
+        targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Format
         run: cargo fmt --all -- --check
       - name: Build
@@ -132,6 +135,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
+      - uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
       - name: Format
         run: cargo fmt --all -- --check
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - ".editorconfig"
       - ".github/workflows/nix-build.yml"
       - ".github/workflows/update-flake.yml"
-      - ".vscode/**"
+      # - ".vscode/**"
       - "CONTRIBUTING.md"
       - "LICENSE"
       - "README.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - ".editorconfig"
       - ".github/workflows/nix-build.yml"
       - ".github/workflows/update-flake.yml"
-      # - ".vscode/**"
+      - ".vscode/**"
       - "CONTRIBUTING.md"
       - "LICENSE"
       - "README.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - ".dockerignore"
       - ".editorconfig"
       - ".github/*"
-      - ".github/workflows/create-release-draft.yml"
-      - ".github/workflows/dev-release.yml"
       - ".github/workflows/nix-build.yml"
       - ".github/workflows/update-flake.yml"
       - ".vscode/**"

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -193,10 +193,9 @@ jobs:
       - name: Print target version
         run: |
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
-      - name: Install rust target
-        run: |
-          rustup update
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+      - uses: dtolnay/rust-toolchain@stable
+        components: clippy, rustfmt
+        targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Test
         run: |
           cargo test \
@@ -227,7 +226,7 @@ jobs:
       - name: Create ZIP archive
         run: |
           ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-Universal.zip
-      
+
       # This doesn't work:
       #
       # - name: Upload artifacts to Github Releases

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -135,10 +135,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@main
-      - name: Install rust target
-        run: |
-          rustup update
-          rustup target add aarch64-apple-darwin x86_64-apple-darwin
+      - uses: dtolnay/rust-toolchain@stable
+        targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Test
         run: |
           cargo test \


### PR DESCRIPTION
For some odd reason github Actions is unable to run cargo fmt. It previously did.
I tried a few times, but it is still not working. This PR explicitly installs cargo with the correct components