### PR TITLE
Fix subcommand help displaying main help instead of specific help (#2483)

### DIFF
--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(


### PR DESCRIPTION
When running commands like `espanso service --help` or `espanso package --help`, the CLI was displaying the main application help instead of the specific subcommand help.

This was caused by using `clap_instance.print_help()` which always prints the root command help, instead of using `err.exit()` which properly handles contextual help for subcommands.

Fixes #2483