### PR TITLE
Fix json label replace (#1702)

### DIFF
--- a/espanso/src/cli/match_cli/list.rs
+++ b/espanso/src/cli/match_cli/list.rs
@@ -105,9 +105,15 @@ pub fn print_matches_as_json(match_list: &[&Match]) -> Result<()> {
             MatchCause::Regex(regex_cause) => vec![regex_cause.regex.clone()],
         };
 
+        let replace = match &m.effect {
+            espanso_config::matches::MatchEffect::Text(text_effect) => text_effect.replace.clone(),
+            espanso_config::matches::MatchEffect::Image(image_effect) => image_effect.path.clone(),
+            espanso_config::matches::MatchEffect::None => String::new(),
+        };
+
         entries.push(JsonMatchEntry {
             triggers,
-            replace: m.description().to_string(),
+            replace,
             label: m.label.clone(),
         });
     }

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(


### PR DESCRIPTION
The `espanso match list --json` command was incorrectly showing the label value in the replace field when a label was present.

  Now the JSON output correctly shows the actual replacement text in the `replace` field and the label separately in the `label` field.

Fixes #1702