### PR TITLE
feat: Add max_regex_buffer_size config option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "[json]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "biomejs.biome"
+    }
+}

--- a/espanso-config/src/config/default.rs
+++ b/espanso-config/src/config/default.rs
@@ -23,3 +23,4 @@ pub const DEFAULT_SHORTCUT_EVENT_DELAY: usize = 10;
 pub const DEFAULT_RESTORE_CLIPBOARD_DELAY: usize = 300;
 pub const DEFAULT_POST_FORM_DELAY: usize = 200;
 pub const DEFAULT_POST_SEARCH_DELAY: usize = 200;
+pub const DEFAULT_MAX_REGEX_BUFFER_SIZE: usize = 30;

--- a/espanso-config/src/config/mod.rs
+++ b/espanso-config/src/config/mod.rs
@@ -162,6 +162,13 @@ pub trait Config: Send + Sync {
     // The maximum height that a form window can take.
     fn max_form_height(&self) -> usize;
 
+    /// The maximum number of characters to hold in the buffer for regex-based triggers.
+    /// This value determines the "memory" of the matcher, affecting the maximum length
+    /// of a trigger that can be detected.
+    /// A larger value allows for more complex and longer triggers, but it also increases
+    /// memory consumption. It's advisable to keep this value reasonably low.
+    fn max_regex_buffer_size(&self) -> usize;
+
     // The number of milliseconds to wait after the search bar has been closed.
     // This is useful to let the target application regain focus
     // after the search bar has been closed, otherwise the injection might
@@ -232,6 +239,8 @@ pub trait Config: Send + Sync {
         show_notifications: {:?}
         secure_input_notification: {:?}
 
+        max_regex_buffer_size: {:?}
+
         x11_use_xclip_backend: {:?}
         x11_use_xdotool_backend: {:?}
         win32_exclude_orphan_events: {:?}
@@ -268,6 +277,8 @@ pub trait Config: Send + Sync {
           self.show_icon(),
           self.show_notifications(),
           self.secure_input_notification(),
+
+          self.max_regex_buffer_size(),
 
           self.x11_use_xclip_backend(),
           self.x11_use_xdotool_backend(),

--- a/espanso-config/src/config/parse/mod.rs
+++ b/espanso-config/src/config/parse/mod.rs
@@ -48,6 +48,7 @@ pub struct ParsedConfig {
     pub max_form_width: Option<usize>,
     pub max_form_height: Option<usize>,
     pub post_search_delay: Option<usize>,
+    pub max_regex_buffer_size: Option<usize>,
     pub emulate_alt_codes: Option<bool>,
     pub win32_exclude_orphan_events: Option<bool>,
     pub win32_keyboard_layout_cache_interval: Option<i64>,

--- a/espanso-config/src/config/parse/yaml.rs
+++ b/espanso-config/src/config/parse/yaml.rs
@@ -128,6 +128,9 @@ pub struct YAMLConfig {
     pub win32_keyboard_layout_cache_interval: Option<i64>,
 
     #[serde(default)]
+    pub max_regex_buffer_size: Option<usize>,
+
+    #[serde(default)]
     pub x11_use_xclip_backend: Option<bool>,
 
     #[serde(default)]
@@ -226,6 +229,8 @@ impl TryFrom<YAMLConfig> for ParsedConfig {
 
             emulate_alt_codes: yaml_config.emulate_alt_codes,
 
+            max_regex_buffer_size: yaml_config.max_regex_buffer_size,
+
             win32_exclude_orphan_events: yaml_config.win32_exclude_orphan_events,
             win32_keyboard_layout_cache_interval: yaml_config.win32_keyboard_layout_cache_interval,
             x11_use_xclip_backend: yaml_config.x11_use_xclip_backend,
@@ -290,6 +295,7 @@ mod tests {
     max_form_height: 500
     post_search_delay: 400
     emulate_alt_codes: true
+    max_regex_buffer_size: 30
     win32_exclude_orphan_events: false
     win32_keyboard_layout_cache_interval: 300
     x11_use_xclip_backend: true
@@ -346,6 +352,7 @@ mod tests {
                 show_notifications: Some(false),
                 secure_input_notification: Some(false),
                 emulate_alt_codes: Some(true),
+                max_regex_buffer_size: Some(30),
                 post_form_delay: Some(300),
                 max_form_width: Some(700),
                 max_form_height: Some(500),

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -21,6 +21,7 @@ use super::{
     default::{
         DEFAULT_CLIPBOARD_THRESHOLD, DEFAULT_POST_FORM_DELAY, DEFAULT_POST_SEARCH_DELAY,
         DEFAULT_PRE_PASTE_DELAY, DEFAULT_RESTORE_CLIPBOARD_DELAY, DEFAULT_SHORTCUT_EVENT_DELAY,
+        DEFAULT_MAX_REGEX_BUFFER_SIZE
     },
     parse::ParsedConfig,
     path::calculate_paths,
@@ -324,6 +325,12 @@ impl Config for ResolvedConfig {
         self.parsed.max_form_height.unwrap_or(500)
     }
 
+    fn max_regex_buffer_size(&self) -> usize {
+        self.parsed
+            .max_regex_buffer_size.
+            unwrap_or(DEFAULT_MAX_REGEX_BUFFER_SIZE)
+    }
+
     fn post_search_delay(&self) -> usize {
         self.parsed
             .post_search_delay
@@ -437,6 +444,7 @@ impl ResolvedConfig {
             post_form_delay,
             max_form_width,
             max_form_height,
+            max_regex_buffer_size,
             post_search_delay,
             win32_exclude_orphan_events,
             win32_keyboard_layout_cache_interval,

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -19,9 +19,9 @@
 
 use super::{
     default::{
-        DEFAULT_CLIPBOARD_THRESHOLD, DEFAULT_POST_FORM_DELAY, DEFAULT_POST_SEARCH_DELAY,
-        DEFAULT_PRE_PASTE_DELAY, DEFAULT_RESTORE_CLIPBOARD_DELAY, DEFAULT_SHORTCUT_EVENT_DELAY,
-        DEFAULT_MAX_REGEX_BUFFER_SIZE
+        DEFAULT_CLIPBOARD_THRESHOLD, DEFAULT_MAX_REGEX_BUFFER_SIZE, DEFAULT_POST_FORM_DELAY,
+        DEFAULT_POST_SEARCH_DELAY, DEFAULT_PRE_PASTE_DELAY, DEFAULT_RESTORE_CLIPBOARD_DELAY,
+        DEFAULT_SHORTCUT_EVENT_DELAY,
     },
     parse::ParsedConfig,
     path::calculate_paths,
@@ -327,8 +327,8 @@ impl Config for ResolvedConfig {
 
     fn max_regex_buffer_size(&self) -> usize {
         self.parsed
-            .max_regex_buffer_size.
-            unwrap_or(DEFAULT_MAX_REGEX_BUFFER_SIZE)
+            .max_regex_buffer_size
+            .unwrap_or(DEFAULT_MAX_REGEX_BUFFER_SIZE)
     }
 
     fn post_search_delay(&self) -> usize {

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -168,7 +168,7 @@ pub fn initialize_and_spawn(
             let regex_matcher = RegexMatcherAdapter::new(
                 &match_converter.get_regex_matches(),
                 &RegexMatcherAdapterOptions {
-                    max_buffer_size: 30, // TODO: load from configs
+                    max_buffer_size: default_config.max_regex_buffer_size(),
                 },
             );
             let matchers: Vec<

--- a/espanso/src/patch/patches/mod.rs
+++ b/espanso/src/patch/patches/mod.rs
@@ -57,5 +57,6 @@ generate_patchable_config!(
   win32_keyboard_layout_cache_interval -> i64,
   x11_use_xclip_backend -> bool,
   x11_use_xdotool_backend -> bool,
+  max_regex_buffer_size -> usize,
   keyboard_layout -> Option<RMLVOConfig>
 );

--- a/espanso/src/res/config/default.yml
+++ b/espanso/src/res/config/default.yml
@@ -39,4 +39,14 @@
 # uses the clipboard if the text is longer than 'clipboard_threshold' characters.
 # clipboard_threshold: 100
 
+# --- Regex Buffer Size
+
+# The maximum number of characters to hold in memory for regex triggers.
+# This value determines the maximum length of a regex trigger that can be
+# matched by espanso and by default have 30 chars.
+# It's advisable to keep this value reasonably low.
+# You might want to increase this value if you have very long triggers,
+# at the cost of higher memory usage.
+# max_regex_buffer_size: 30
+
 # For a list of all the available options, visit the official docs at: https://espanso.org/docs/

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -21,7 +21,11 @@
     "filter_os": {
       "description": "OS specific filter",
       "type": "string",
-      "enum": ["linux", "macos", "windows"]
+      "enum": [
+        "linux",
+        "macos",
+        "windows"
+      ]
     },
     "extra_includes": {
       "type": "array",
@@ -151,7 +155,11 @@
     },
     "backend": {
       "type": "string",
-      "enum": ["clipboard", "inject", "auto"],
+      "enum": [
+        "clipboard",
+        "inject",
+        "auto"
+      ],
       "default": "auto",
       "description": "The mechanism used to perform the injection. Espanso can either inject text by simulating keypresses (Inject backend) or by using the clipboard (Clipboard backend). Both of them have pros and cons, so the Auto backend is used by default to automatically choose the most appropriate one based on the situation. If for whatever reason the Auto backend is not appropriate, you can change this option to override it."
     },
@@ -211,6 +219,11 @@
       "type": "number",
       "default": 500,
       "description": "Maximum height of a form window."
+    },
+    "max_regex_buffer_size": {
+      "type": "number",
+      "default": 50,
+      "description": "The max number of characters held in memory for regex matching"
     },
     "post_search_delay": {
       "type": "number",


### PR DESCRIPTION
This PR introduces a new configuration option, `max_regex_buffer_size`, allowing users to control the maximum number of characters held in memory for regex trigger matching and solve the issue #1766 .

## Context

Previously, the buffer size for regex matching was hardcoded to 30 characters. This posed a limitation for users wanting to create triggers longer than this size.
This change makes the regex buffer size configurable in the configuration, providing a better balance between capability and resource consumption, tailored to each user's needs.

---

## Changes Made

* **New Configuration Option:** Added `max_regex_buffer_size` to the configuration files, with a default value.
* **Config Trait:** Updated the Config trait and its implementations to include the `max_regex_buffer_size()` method.
* **Engine Integration:** The regex matcher now uses the value from the configuration instead of a hardcoded one.
* **Documentation:** Added comments in both the source code and the default configuration file to explain the new option.

---

## How to Test

1. Open your `default.yml` configuration file.
2. Set a small buffer size:

   ```yml
   max_regex_buffer_size: 10
   ```
3. Create a match with a regex trigger longer than 10 characters:

   ```yml
   matches:
     - regex: ":thisislongerthan10"
       replace: "This should not work."
   ```
4. Save the file and let espanso restart.
5. Try to type `:thisislongerthan10`. The replacement should **not** occur.
6. Now, increase the buffer size in `default.yml`:

   ```yml
   max_regex_buffer_size: 20
   ```
7. Save and let espanso restart.
8. Try to type `:thisislongerthan10` again. The replacement should now work correctly.

