### PR TITLE
Restore launching from app bundle on macos

### DIFF
--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -84,7 +84,6 @@ fn main() {
     let processed_args = preprocess_aliases(args);
 
     let mut clap_instance = App::new("espanso")
-    .arg_required_else_help(true)
     .version(VERSION)
     .long_version(VERSION)
     .author("Federico Terzi and the espanso contributors")
@@ -441,7 +440,7 @@ SubCommand::with_name("install")
     {
         Ok(matches) => matches,
         Err(err) => match err.kind {
-            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
+            ErrorKind::DisplayHelp => {
                 err.exit();
             }
             ErrorKind::DisplayVersion => {
@@ -601,6 +600,12 @@ SubCommand::with_name("install")
         let exit_code = (handler.entry)(cli_args);
 
         std::process::exit(exit_code);
+    } else {
+        // No handler at this point means subcommand was not provided. Could also use clap's
+        // `arg_required_else_help`, but that makes it more difficult to handle launching from app
+        // bundle on macos, which will not have a subcommand specified.
+        clap_instance.print_help().expect("unable to print help");
+        std::process::exit(1);
     }
 }
 


### PR DESCRIPTION
When launching from app bundle on macos a subcommand is not specified.

Consequently, setting `arg_required_else_help(true)` results in
`ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand`.

Instead of trying to match on this specific error only on macos, it's
simpler to revert to prior behavior of managing this ourselves instead
of relying on `clap`.

Fixes https://github.com/espanso/espanso/issues/2444

Likely fixes https://github.com/espanso/espanso/issues/2475
