### PR TITLE
Fix numpad Enter not confirming choices in search menu (#1618)

### DIFF
--- a/espanso-modulo/src/sys/search/search.cpp
+++ b/espanso-modulo/src/sys/search/search.cpp
@@ -288,7 +288,7 @@ void SearchFrame::OnCharEvent(wxKeyEvent &event) {
         SelectNext();
     } else if (event.GetKeyCode() == 'P' && event.RawControlDown()) {
         SelectPrevious();
-    } else if (event.GetKeyCode() == WXK_RETURN) {
+    } else if (event.GetKeyCode() == WXK_RETURN || event.GetKeyCode() == WXK_NUMPAD_ENTER) {
         Submit();
     } else {
         event.Skip();

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(


### PR DESCRIPTION
When using the search menu, pressing the numpad Enter key did not confirm the selected choice. Only the standard Enter key worked.

Now both the standard Enter key and the numpad Enter key properly confirm the selected choice in the search menu.

Fixes #1618