### PR TITLE
Fix empty triggers causing expansion on every word separator (#1616)

### DIFF
--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -140,6 +140,24 @@ pub fn try_convert_into_match(
         yaml_match.triggers
     };
 
+    // Filter out empty triggers and add a warning
+    let triggers = if let Some(mut triggers_vec) = triggers {
+        let original_len = triggers_vec.len();
+        triggers_vec.retain(|t| !t.trim().is_empty());
+        if triggers_vec.len() < original_len {
+            warnings.push(anyhow!(
+                "empty triggers are not allowed and have been ignored"
+            ));
+        }
+        if triggers_vec.is_empty() {
+            None
+        } else {
+            Some(triggers_vec)
+        }
+    } else {
+        None
+    };
+
     let uppercase_style = match yaml_match
         .uppercase_style
         .map(|s| s.to_lowercase())

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(


### PR DESCRIPTION
When a trigger was set to an empty string (""), it would expand on every word separator, causing unexpected text replacements.

Now empty triggers are filtered out during configuration parsing, and a warning is displayed in the logs to inform that empty triggers are not allowed and have been ignored.

Fixes #1616