### PR TITLE
Fix utf8 bom parsing (#2510)

### DIFF
--- a/espanso-config/src/config/parse/yaml.rs
+++ b/espanso-config/src/config/parse/yaml.rs
@@ -165,6 +165,9 @@ pub struct YAMLConfig {
 
 impl YAMLConfig {
     pub fn parse_from_str(yaml: &str) -> Result<Self> {
+        // Remove UTF-8 BOM if present (common in Windows editors like Notepad)
+        let yaml = yaml.trim_start_matches('\u{FEFF}');
+
         // Because an empty string is not valid YAML but we want to support it anyway
         if is_yaml_empty(yaml) {
             return Ok(serde_yaml::from_str(

--- a/espanso-config/src/matches/group/loader/yaml/parse.rs
+++ b/espanso-config/src/matches/group/loader/yaml/parse.rs
@@ -39,6 +39,9 @@ pub struct YAMLMatchGroup {
 
 impl YAMLMatchGroup {
     pub fn parse_from_str(yaml: &str) -> Result<Self> {
+        // Remove UTF-8 BOM if present (common in Windows editors like Notepad)
+        let yaml = yaml.trim_start_matches('\u{FEFF}');
+
         // Because an empty string is not valid YAML but we want to support it anyway
         if is_yaml_empty(yaml) {
             return Ok(serde_yaml::from_str(

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(


### PR DESCRIPTION
This PR fixes issue #2510 where YAML configuration and match files created with Windows editors (like Notepad) that add a UTF-8 BOM were not parsed correctly by espanso.

Changes :
- Added UTF-8 BOM removal (\u{FEFF}) in YAMLMatchGroup::parse_from_str() and YAMLConfig::parse_from_str().
- Simplified the parse_from_file() methods to rely on parse_from_str() for consistent BOM handling.

Fixes #2510