### PR TITLE
Fix "kdotool missing or not available" on macOS (#2509)

### DIFF
--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -20,7 +20,10 @@
 // This is needed to avoid showing a console window when starting espanso on Windows
 #![windows_subsystem = "windows"]
 
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+use std::process::Command;
 
 use clap::{App, AppSettings, Arg, ArgMatches, ErrorKind, SubCommand};
 use cli::{CliModule, CliModuleArgs};

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -584,6 +584,7 @@ SubCommand::with_name("install")
         }
 
         // try to invoke `kdotool` to see if you have it or not.
+        #[cfg(target_os = "linux")]
         if Command::new("kdotool")
             .arg("getactivewindow")
             .arg("getwindowclassname")


### PR DESCRIPTION
The kdotool availability check was running unconditionally on all platforms, but kdotool is a Linux-specific tool. This PR adds a `#[cfg(target_os = "linux")]` attribute to restrict the check to Linux only.

🚨 I did not test this because I am on Windows.

Fixes #2509