### PR TITLE
Replace markdown library to fix nested lists rendering (#2217)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.8",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ dependencies = [
  "libc",
  "regex",
  "terminal_size",
- "unicode-width",
+ "unicode-width 0.1.8",
  "winapi 0.3.9",
 ]
 
@@ -998,7 +998,7 @@ dependencies = [
  "crossbeam",
  "html2text",
  "log",
- "markdown",
+ "pulldown-cmark",
  "thiserror 1.0.56",
  "unicode-segmentation",
 ]
@@ -1381,6 +1381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,7 +1495,7 @@ dependencies = [
  "markup5ever",
  "tendril",
  "thiserror 1.0.56",
- "unicode-width",
+ "unicode-width 0.1.8",
  "xml5ever",
 ]
 
@@ -1828,17 +1837,6 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "time 0.3.15",
-]
-
-[[package]]
-name = "markdown"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd"
-dependencies = [
- "lazy_static",
- "pipeline",
- "regex",
 ]
 
 [[package]]
@@ -2387,12 +2385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pipeline"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
-
-[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2474,25 @@ checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.9.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pure-rust-locales"
@@ -3522,6 +3533,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"

--- a/espanso-engine/Cargo.toml
+++ b/espanso-engine/Cargo.toml
@@ -9,7 +9,7 @@ log.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 crossbeam.workspace = true
-markdown = "0.3.0"
+pulldown-cmark = "0.13.0"
 html2text = "0.12.0"
 unicode-segmentation = "1.9.0"
 

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -442,8 +442,7 @@ SubCommand::with_name("install")
         Ok(matches) => matches,
         Err(err) => match err.kind {
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand | ErrorKind::DisplayHelp => {
-                clap_instance.print_help().expect("unable to print help");
-                std::process::exit(1);
+                err.exit();
             }
             ErrorKind::DisplayVersion => {
                 println!(


### PR DESCRIPTION
This PR replaces the `markdown 0.3.0` library with `pulldown-cmark 0.13.0` to fix #2217, where nested lists were generating excessive `<p>` tags inside `<li>` elements.

It may fix #759, fix #818, fix #1294, 
and possibly #1613, and #2114.

I did not test it for real, only with unit tests.

🚨 I'm not sure if changing a core dependency is appropriate here... I'm trying to do my best with these contributions, so please don't hesitate to tell me if I'm going in the wrong direction. 🙂