### PR TITLE
Prefer the GHA-provided rust tooling

### DIFF
--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       #   - name: Format
       #     run: cargo fmt --all -- --check
       - name: Install Linux X11 dependencies
@@ -57,9 +54,6 @@ jobs:
     runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       #   - name: Format
       #     run: cargo fmt --all -- --check
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       - name: Format
         run: cargo fmt --all -- --check
       - name: Install Linux X11 dependencies
@@ -75,9 +72,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       - name: Format
         run: cargo fmt --all -- --check
       - name: Install Linux wayland dependencies
@@ -116,10 +110,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-          targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Format
         run: cargo fmt --all -- --check
       - name: Build
@@ -135,9 +125,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       - name: Format
         run: cargo fmt --all -- --check
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Build
         run: |
           cargo build --target aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
           cargo build --target x86_64-apple-darwin
       - name: Clippy
         run: |

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -193,10 +193,6 @@ jobs:
       - name: Print target version
         run: |
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
-          targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Test
         run: |
           cargo test \

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -195,6 +195,7 @@ jobs:
           echo Using version ${{ needs.extract-version.outputs.espanso_version }}
       - name: Test
         run: |
+          rustup target add x86_64-apple-darwin
           cargo test \
             -p espanso \
             --target x86_64-apple-darwin \
@@ -207,6 +208,7 @@ jobs:
             --features native-tls,modulo
       - name: Build
         run: |
+          rustup target add x86_64-apple-darwin
           cargo build \
             -p espanso \
             --target x86_64-apple-darwin \

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -135,9 +135,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@main
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin, x86_64-apple-darwin
       - name: Test
         run: |
           cargo test \

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -137,6 +137,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Test
         run: |
+          rustup target add x86_64-apple-darwin
           cargo test \
             -p espanso \
             --target x86_64-apple-darwin \
@@ -149,6 +150,7 @@ jobs:
             --features native-tls,modulo
       - name: Build
         run: |
+          rustup target add x86_64-apple-darwin
           cargo build \
             -p espanso \
             --target x86_64-apple-darwin \


### PR DESCRIPTION
GitHub Actions can potentially be a significant security vulnerability;
we should try to avoid unnecessary dependencies.

The recent breakage seems to have been a transient issue; going
forward, I would advise that -- should we face such an issue again
-- we try temporarily pinning our runner image or our action to a
stable version (e.g. `ubuntu-24.04` as opposed to `ubuntu-latest`,
`actions/checkout@v4` as opposed to `actions/checkout@main`). Then we
can just revert back to latest or main once the issue has sorted itself
out.
