### PR TITLE
use actions cache

### DIFF
--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -14,6 +14,13 @@ jobs:
   linux-arm:
     runs-on: ubuntu-24.04-arm
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       #   - name: Format
       #     run: cargo fmt --all -- --check
@@ -53,6 +60,13 @@ jobs:
   windows-arm:
     runs-on: windows-11-arm
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       #   - name: Format
       #     run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
   linux-x11:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Format
         run: cargo fmt --all -- --check
@@ -72,6 +79,13 @@ jobs:
   linux-wayland:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Format
         run: cargo fmt --all -- --check
@@ -110,6 +124,13 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Format
         run: cargo fmt --all -- --check
@@ -126,6 +147,13 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Format
         run: cargo fmt --all -- --check

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -31,6 +31,13 @@ jobs:
     outputs:
       espanso_version: ${{ steps.version.outputs.version }}
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: "Extract version"
         id: "version"
@@ -46,6 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Create new release
         # gh release create docs: https://cli.github.com/manual/gh_release_create
@@ -70,6 +84,13 @@ jobs:
         shell: bash
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Print target version
         run: |
@@ -136,6 +157,13 @@ jobs:
     continue-on-error: false
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Print target version
         run: |
@@ -162,6 +190,13 @@ jobs:
     continue-on-error: false
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Print target version
         run: |
@@ -189,6 +224,13 @@ jobs:
     continue-on-error: false
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Print target version
         run: |

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -30,6 +30,13 @@ jobs:
         shell: bash
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Build
         run: |
@@ -71,6 +78,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Install Linux dependencies
         run: |
@@ -104,6 +118,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Install Linux dependencies
         run: |
@@ -134,6 +155,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - uses: actions/cache@main
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions/checkout@main
       - name: Test
         run: |


### PR DESCRIPTION
- **Cache rust artifacts with the official GHA actions/cache**
- **We want to run CI on pushes, not just PRs**
