### PR TITLE
Add timezone support to date extension (#2225)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1123,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "chrono-tz",
  "enum-as-inner 0.6.0",
  "log",
  "rand 0.8.3",
@@ -1848,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf",
+ "phf 0.10.1",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -2327,6 +2338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,7 +2382,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.6",
 ]
 
 [[package]]
@@ -2371,7 +2391,16 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.6",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher 1.0.1",
 ]
 
 [[package]]
@@ -3043,6 +3072,12 @@ name = "siphasher"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/espanso-render/Cargo.toml
+++ b/espanso-render/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 regex.workspace = true
 chrono = { version = "0.4.41", features = ["unstable-locales"] }
+chrono-tz = "0.10"
 enum-as-inner.workspace = true
 rand = "0.8.3"
 sys-locale = "0.1.0"

--- a/espanso-render/src/extension/date.rs
+++ b/espanso-render/src/extension/date.rs
@@ -18,6 +18,7 @@
  */
 
 use chrono::{DateTime, Duration, Local, Locale};
+use chrono_tz::Tz;
 
 use crate::{Extension, ExtensionOutput, ExtensionResult, Number, Params, Value};
 
@@ -60,16 +61,39 @@ impl Extension for DateExtension<'_> {
             now += offset;
         }
 
+        // Convert to target timezone if specified
+        let tz_param = params.get("tz").and_then(|val| val.as_string());
+
         let format = params.get("format");
         let locale = params
             .get("locale")
             .and_then(|val| val.as_string())
             .map_or_else(|| self.locale_provider.get_system_locale(), String::from);
 
-        let date = if let Some(Value::String(format)) = format {
-            DateExtension::format_date_with_locale_string(now, format, &locale)
+        let date = if let Some(tz_str) = tz_param {
+            // Try to parse the timezone string
+            if let Ok(tz) = tz_str.parse::<Tz>() {
+                let converted = now.with_timezone(&tz);
+                if let Some(Value::String(format)) = format {
+                    DateExtension::format_date_with_locale_and_tz(converted, format, &locale)
+                } else {
+                    converted.to_rfc2822()
+                }
+            } else {
+                // Invalid timezone, fallback to local time
+                if let Some(Value::String(format)) = format {
+                    DateExtension::format_date_with_locale_string(now, format, &locale)
+                } else {
+                    now.to_rfc2822()
+                }
+            }
         } else {
-            now.to_rfc2822()
+            // No timezone specified, use local time
+            if let Some(Value::String(format)) = format {
+                DateExtension::format_date_with_locale_string(now, format, &locale)
+            } else {
+                now.to_rfc2822()
+            }
         };
 
         ExtensionResult::Success(ExtensionOutput::Single(date))
@@ -96,6 +120,15 @@ impl DateExtension<'_> {
     ) -> String {
         let locale = convert_locale_string_to_locale(locale_str).unwrap_or(Locale::en_US);
         Self::format_date_with_locale(date, format, locale)
+    }
+
+    fn format_date_with_locale_and_tz(
+        date: DateTime<Tz>,
+        format: &str,
+        locale_str: &str,
+    ) -> String {
+        let locale = convert_locale_string_to_locale(locale_str).unwrap_or(Locale::en_US);
+        date.format_localized(format, locale).to_string()
     }
 }
 
@@ -566,5 +599,99 @@ mod tests {
                 .unwrap(),
             ExtensionOutput::Single("martedì".to_string())
         );
+    }
+
+    #[test]
+    fn utc_timezone_works() {
+        let locale_provider = MockLocaleProvider::new();
+        let mut extension = DateExtension::new(&locale_provider);
+        extension.fixed_date = Some(
+            Local
+                .with_ymd_and_hms(2014, 7, 8, 12, 0, 0)
+                .single()
+                .unwrap(),
+        );
+
+        let param = vec![
+            ("format".to_string(), Value::String("%Y-%m-%d %H:%M:%S".to_string())),
+            ("tz".to_string(), Value::String("UTC".to_string())),
+        ]
+        .into_iter()
+        .collect::<Params>();
+
+        let result = extension
+            .calculate(&crate::Context::default(), &HashMap::default(), &param)
+            .into_success()
+            .unwrap();
+
+        // The result should be formatted in UTC timezone
+        // Just verify we got a Single output with a valid datetime string
+        match result {
+            ExtensionOutput::Single(s) => {
+                assert!(s.contains("2014"));
+                assert!(s.contains("07"));
+            }
+            _ => panic!("Expected Single output"),
+        }
+    }
+
+    #[test]
+    fn named_timezone_works() {
+        let locale_provider = MockLocaleProvider::new();
+        let mut extension = DateExtension::new(&locale_provider);
+        extension.fixed_date = Some(
+            Local
+                .with_ymd_and_hms(2014, 7, 8, 12, 0, 0)
+                .single()
+                .unwrap(),
+        );
+
+        let param = vec![
+            ("format".to_string(), Value::String("%Y-%m-%d %H:%M:%S".to_string())),
+            ("tz".to_string(), Value::String("America/New_York".to_string())),
+        ]
+        .into_iter()
+        .collect::<Params>();
+
+        let result = extension
+            .calculate(&crate::Context::default(), &HashMap::default(), &param)
+            .into_success()
+            .unwrap();
+
+        // The result should be formatted in America/New_York timezone
+        match result {
+            ExtensionOutput::Single(s) => {
+                assert!(s.contains("2014"));
+                assert!(s.contains("07"));
+            }
+            _ => panic!("Expected Single output"),
+        }
+    }
+
+    #[test]
+    fn invalid_timezone_fallback_to_local() {
+        let locale_provider = MockLocaleProvider::new();
+        let mut extension = DateExtension::new(&locale_provider);
+        extension.fixed_date = Some(
+            Local
+                .with_ymd_and_hms(2014, 7, 8, 9, 10, 11)
+                .single()
+                .unwrap(),
+        );
+
+        let param = vec![
+            ("format".to_string(), Value::String("%H:%M:%S".to_string())),
+            ("tz".to_string(), Value::String("Invalid/Timezone".to_string())),
+        ]
+        .into_iter()
+        .collect::<Params>();
+
+        // Should fallback to local time without crashing
+        let result = extension
+            .calculate(&crate::Context::default(), &HashMap::default(), &param)
+            .into_success()
+            .unwrap();
+
+        assert_eq!(result, ExtensionOutput::Single("09:10:11".to_string()));
     }
 }


### PR DESCRIPTION
Allow users to format dates in different timezones using the optional 'tz' parameter. Supports IANA timezone names (e.g., UTC, America/New_York, Europe/Paris) and falls back to local time for invalid timezones.

- Added `chrono-tz` dependency to `espanso-render/Cargo.toml`.
- Modified `date.rs` to support timezone conversion via new `tz` parameter.
- Added helper function `format_date_with_locale_and_tz()` for timezone-aware formatting.
- Added 3 new unit tests covering UTC, named timezones, and invalid timezone fallback.

Fixes #2225