### PR TITLE
Add support for dynamic offset variables in date extension

### DIFF
--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -261,7 +261,8 @@
                   "type": "string"
                 },
                 "offset": {
-                  "type": "number"
+                  "type": ["number", "string"],
+                  "description": "Time offset in seconds. Can be a number or a string (to support variable injection like {{hours_offset}})"
                 },
                 "tz": {
                   "type": "string",


### PR DESCRIPTION
Adds support for dynamic offset variables in the date extension.
The `offset` parameter can now accept both numbers and strings (for variable injection).
Maintains full backward compatibility with existing numeric offsets.