### PR TITLE
Add trim option to script extension schema

### DIFF
--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -227,6 +227,10 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "trim": {
+                  "type": "boolean",
+                  "description": "Trim the output of the script. Useful if the script has an excess in spaces or newlines"
                 }
               }
             },


### PR DESCRIPTION
Closes #2551

This pull request adds the missing `trim` option to the JSON schema definition for the Script Extension. The `trim` boolean property was introduced in a past update but was not reflected in the schema.