### PR TITLE
Restore espansion in the welcome screen

### DIFF
--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -282,6 +282,7 @@ pub fn initialize_and_spawn(
                 }
             }
 
+            let mut welcome_handle = None;
             match start_reason.as_deref() {
                 Some(flag) if flag == WORKER_START_REASON_CONFIG_CHANGED => {
                     notification_manager.notify_config_reloaded(false);
@@ -296,7 +297,7 @@ pub fn initialize_and_spawn(
                     notification_manager.notify_start();
 
                     if !preferences.has_displayed_welcome() {
-                        super::ui::welcome::show_welcome_screen();
+                        welcome_handle = super::ui::welcome::show_welcome_screen();
                         preferences.set_has_displayed_welcome(true);
                     }
                 }
@@ -304,6 +305,9 @@ pub fn initialize_and_spawn(
 
             let mut engine = espanso_engine::Engine::new(&funnel, &mut processor, &dispatcher);
             let exit_mode = engine.run();
+            if let Some(mut handle) = welcome_handle {
+                handle.wait().expect("welcome screen died");
+            };
 
             info!("engine eventloop has terminated, propagating exit event...");
             ui_remote.exit();

--- a/espanso/src/cli/worker/ui/welcome.rs
+++ b/espanso/src/cli/worker/ui/welcome.rs
@@ -16,20 +16,18 @@
  * You should have received a copy of the GNU General Public License
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
+use std::process::Child;
 
 #[cfg(feature = "modulo")]
-pub fn show_welcome_screen() {
+pub fn show_welcome_screen() -> Option<Child> {
     let espanso_exe_path = std::env::current_exe().expect("unable to determine executable path");
     let mut command = std::process::Command::new(espanso_exe_path.to_string_lossy().to_string());
     command.args(["modulo", "welcome"]);
 
-    let _ = command
-        .spawn()
-        .expect("unable to show welcome screen")
-        .wait();
+    Some(command.spawn().expect("unable to show welcome screen"))
 }
 
 #[cfg(not(feature = "modulo"))]
-pub fn show_welcome_screen() {
-    // NOOP
+pub fn show_welcome_screen() -> Option<Child> {
+    None
 }


### PR DESCRIPTION
The addition of the `wait` in 7bae4770073eac000c7711df8af8925509cefd1c broke expansion in the welcome screen.

Fixes https://github.com/espanso/espanso/issues/2571
