### PR TITLE
Docs update: Improving build notes around Windows and WSL

### DIFF
--- a/docs/src/ch03-00-building-and-compilation.md
+++ b/docs/src/ch03-00-building-and-compilation.md
@@ -2,6 +2,10 @@
 
 This chapter explains the various steps needed to build espanso.
 
+### Cross-compilation
+
+At the time of writing, cross-compilation is not guaranteed to be supported. In other words, if you wish to build the `exe` files for Windows, you _must_ do this on a PC running Windows. For Windows, this means WSL cannot be used to compile Espanso.
+
 ### Prerequisites
 
 These are the basic tools required to build espanso:
@@ -12,7 +16,9 @@ espanso officially supports the following:
   - On Windows, you should use the MSVC compiler. The easiest way to install
   it is by downloading [Visual Studio](https://visualstudio.microsoft.com/) and checking "Desktop development with C++" in the installer.
   Note that [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
-  alone doesn't fulfill all the requirements for espanso.
+  alone doesn't fulfill all the requirements for espanso - it's recommended to download Visual Studio.
+    - As of the time of writing, you can NOT build in WSL. You _must_ do the build natively in Windows. You must
+    first install Rust for Windows, which requires you to install Microsoft Visual Studio (_Not_ VsCode!).
   - On macOS, you should use the official build tools that come with Xcode. If
   you don't want to install Xcode, you should be able to download only the
   build tools by executing `xcode-select —install` and following the
@@ -23,8 +29,8 @@ espanso officially supports the following:
 
 ### Installing the app
 
-After installing the prerequisites, the following chapters (linux, macos and 
-windows) will guide you on how to install the app with the commandline
+After installing the prerequisites, the following chapters (Linux, macOS and 
+Windows) will guide you on how to install the app with the command line.
 
 ### Advanced compilation
 

--- a/docs/src/ch03-01-windows.md
+++ b/docs/src/ch03-01-windows.md
@@ -1,40 +1,93 @@
 # Windows
 
-After installing the prerequisites, you are ready to compile Espanso on Windows.
+## Prerequisites
 
-Espanso supports multiple targets on Windows: plain executable, installer and portable mode. The following sections explain how to build Espanso for these configurations.
+Compilation of Espanso on Windows requires you to have Rust installed on native Windows (not WSL).
 
-#### Plain executable
+To do this, download and run the official Rust installer for Windows. The Rust installer will inform you that you must
+have a copy of Microsoft Visual Studio installed, which contains a bunch of necessary libraries.  
+The Visual Studio Community Edition is free. Visual Studio _Code_ is a different program and does not contain the
+libraries needed for compilation.
 
-If you only want to build the "plain" Espanso executable, you can do so by running:
+Once you have Visual Studio and Rust installed you are ready to compile Espanso on Windows.
+
+You do not need to use Visual Studio for editing and building the code. Rust simply needs to use Visual Studio's files
+to compile Espanso.
+
+## Building
+
+Espanso supports multiple targets on Windows:
+
+1. Plain executable
+2. Installer
+3. Portable mode
+
+The following sections explain how to build Espanso for these configurations.
+
+### 1. Plain executable
+
+If you only want to build the "plain" Espanso executable, you can do so by running the following command in a
+PowerShell or Command Prompt (or in your IDE of choice):
 
 ```console
 cargo build --no-default-features --features modulo,native-tls --release
 ```
 
-This will create an `espanso` executable in the `target/release` directory.
+This will create an `espanso.exe` executable in the `target/release` directory. You can use this as the command-line
+application, or you can run the GUI by running this command in a PowerShell terminal:
 
-##### Build the resources
+```powershell
+.\target\windows\resources\espansod.exe launcher
+```
 
-There is a setup step you need to make before building the installer and portable
-versions of espanso. After compiling a binary (Release for example)
+> _Note:_ While you can't run this command in your WSL shell itself, you could still host your code in WSL! First, you
+must [map your WSL distro as a mapped network drive in Windows](https://stackoverflow.com/a/78707619). After you have
+done that, navigate to your WSL `espanso` directory using Windows File Explorer. Then, <kbd>shift</kbd> +
+<kbd>right-click</kbd> --> `Open PowerShell window here` and then you can run `cargo` commands to run the build. Your
+code will be compiled in PowerShell by the copy of Rust installed in Windows, and you should be able to edit and
+manage your code in your WSL environment. But your mileage may vary: build times using this method can be
+substantially longer than compiling code hosted in the native Windows file system. You may find that building without
+WSL is a better experience. But at least it _is_ possible to host your code in WSL if you prefer. It is recommended to
+copy the built executables _out_ of WSL and run them from Windows directly, instead of trying to run the executables
+while they are stored within your WSL directory. They _will_ run, but performance will suffer greatly. It seems that
+any "cross-OS" connection between Windows and WSL introduces lots of latency, which is far from ideal.
+
+
+### 2. & 3. Prerequisite: Build the resources
+
+Before building the installer or portable versions of Espanso you must prepare the files. Run the
+`build_windows_resources.ps1` script in Powershell, first setting the `EXEC_PATH` variable to point to your target
+executable. In this example, the `release` executable is used:
 
 ```powershell
 $env:EXEC_PATH = "target\release\espanso.exe"
 scripts\build_windows_resources.ps1
 ```
 
-The variable `$env:EXEC_PATH` can be load of your OS environment variables, and
-the alterntive path of release, would be:
+If you wanted to use the debug target, you would run this command before running `build_windows_resources` instead:
 
 ```powershell
 $env:EXEC_PATH = "target\debug\espanso.exe"
 ```
 
-##### Installer
+This will create files in `target\windows\resources`.
 
-If you want to build the Installer (the executable that installs Espanso on a
-machine), first build the executable as per above. Afterwards, you can run:
+> **Note:** You may get an error in in PowerShell saying _"running scripts is disabled on this system."_ To get around
+this, change the execution policy to allow yourself to run scripts:
+>
+> ```powershell
+> Get-ExecutionPolicy -Scope CurrentUser  # This will simply print what the script-running policy is *currently* set to.
+> Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser
+> ```
+>
+> It _may_ be considered unsafe to leave this security setting disabled, which is why Microsoft has it disabled by
+> default. So you may choose to restore it back to the previous setting, which is printed out by the previous
+> commands. More info can be found [here](https:/go.microsoft.com/fwlink/?LinkID=135170).
+
+### 2. Installer
+
+If you want to build the Installer, the executable that installs Espanso on a
+machine, first build the executable and resources as outlined above. Afterwards, run:
 
 ```powershell
 Install-Module -Name 'PSTOML' -Force # just needed once
@@ -43,7 +96,7 @@ scripts\build_windows_installer.ps1
 
 This will generate the installer in the `target/windows` directory.
 
-##### Portable mode bundle
+### 3. Portable mode bundle
 
 You can also generate a portable-mode bundle (a self-contained ZIP archive that
 does not require installation) by first building the executable as per above, and
@@ -54,4 +107,16 @@ scripts\build_windows_portable.ps1
 ```
 
 This will generate the zip file in the `target/windows` directory.
-There are README instructions inside!.
+There are README instructions inside!
+
+
+## A brief side note about cross-compilation and WSL:
+
+If you try to run these Rust commands in WSL directly the build will _say_ it completes but the resulting application
+will not run when installed on Windows, as it likely defaulted to a Linux build target. Rust supports
+cross-compilation, but the compilation method used for building Espanso for Windows (MSVC) requires files that are
+proprietary to Microsoft and only bundled with Visual Studio. It would not be trivial to change Espanso off of MSVC
+and migrate to an architecture that is friendlier to cross-compilation. If you are new to the Espanso project and
+bring experience with Windows applications and cross-compiling Rust applications across multiple platforms, then
+please feel free to suggest improvements. Others be warned: here be dragons - It is currently easier to build natively
+for each supported platform.


### PR DESCRIPTION
I'm a new contributor and also a Rust noob, and I spent a loooong time trying to figure out how to get the build to work.

For my job I mostly do my dev work on Ubuntu, but at home I'm chained to Windows. As a result, I try to do most of my at-home dev work in WSL instead of Windows natively. I thought I would be able to do that with Espanso, but I spent a long time trying to get it to work. I tried a bunch of workarounds and did a lot of learning about Rust cross-compilation, but in the end I ended up deciding it wasn't worth the massive code changes it would require. So I bailed on my cross-compilation goals, sadly.

However, I am a weirdo who enjoys writing code documentation so I'm documenting my findings about the build on Windows and cleaning up some other ambiguity I found.

Hopefully these changes will help save the time of future contributors and make it easier for new folks to learn how stuff works. 😀