### PR TITLE
Allow multiple choices in the form list to be selected

### DIFF
--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -96,6 +96,7 @@ pub struct ChoiceFieldConfig {
 pub struct ListFieldConfig {
     pub values: Vec<String>,
     pub default: String,
+    pub separator: String,
 }
 
 impl<'de> serde::Deserialize<'de> for FieldConfig {
@@ -144,6 +145,8 @@ impl<'a> From<&'a AutoFieldConfig> for FieldConfig {
                     config.default.clone_from(default);
                 }
 
+                config.separator = other.separator.clone();
+
                 FieldTypeConfig::List(config)
             }
             _ => {
@@ -171,6 +174,10 @@ fn default_values() -> Vec<String> {
     Vec::new()
 }
 
+fn default_separator() -> String {
+    ", ".to_owned()
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AutoFieldConfig {
     #[serde(rename = "type", default = "default_type")]
@@ -184,4 +191,7 @@ pub struct AutoFieldConfig {
 
     #[serde(default = "default_values")]
     pub values: Vec<String>,
+
+    #[serde(default = "default_separator")]
+    pub separator: String,
 }

--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -145,7 +145,7 @@ impl<'a> From<&'a AutoFieldConfig> for FieldConfig {
                     config.default.clone_from(default);
                 }
 
-                config.separator = other.separator.clone();
+                config.separator.clone_from(&other.separator);
 
                 FieldTypeConfig::List(config)
             }

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -51,11 +51,13 @@ fn create_field(token: &Token, field_map: &HashMap<String, FieldConfig>) -> Fiel
                     values: config.values.clone(),
                     choice_type: ChoiceType::Dropdown,
                     default_value: config.default.clone(),
+                    separator: String::new(),
                 }),
                 FieldTypeConfig::List(config) => FieldType::Choice(ChoiceMetadata {
                     values: config.values.clone(),
                     choice_type: ChoiceType::List,
                     default_value: config.default.clone(),
+                    separator: config.separator.clone(),
                 }),
             };
 

--- a/espanso-modulo/src/sys/form/form.cpp
+++ b/espanso-modulo/src/sys/form/form.cpp
@@ -226,7 +226,8 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
             idMap[meta.id] = std::move(field);
         } else {
             choice = (void *)new wxListBox(parent, wxID_ANY, wxDefaultPosition,
-                                           wxDefaultSize, choices);
+                                           wxDefaultSize, choices,
+                                           wxLB_EXTENDED);
 
             if (selectedItem >= 0) {
                 ((wxListBox *)choice)->SetSelection(selectedItem);

--- a/espanso-modulo/src/sys/form/form.cpp
+++ b/espanso-modulo/src/sys/form/form.cpp
@@ -63,9 +63,11 @@ class ChoiceFieldWrapper {
 
 class ListFieldWrapper {
     wxListBox *control;
+    wxString separator;
 
   public:
-    explicit ListFieldWrapper(wxListBox *control) : control(control) {}
+    explicit ListFieldWrapper(wxListBox *control, wxString separator)
+        : control(control), separator(separator) {}
 
     virtual wxString getValue() {
       wxArrayInt selections;
@@ -73,7 +75,7 @@ class ListFieldWrapper {
 
       wxString value = "";
       for (unsigned int i = 0; i < selections.size(); i++) {
-        if (i > 0) value.Append(", ");
+        if (i > 0) value.Append(separator);
         value.Append(control->GetString(selections[i]));
       }
 
@@ -219,6 +221,7 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
         }
 
         void *choice = nullptr;
+        wxString separator = wxString::FromUTF8(choiceMeta->separator);
         if (choiceMeta->choiceType == ChoiceType::DROPDOWN) {
             choice = (void *)new wxChoice(parent, wxID_ANY, wxDefaultPosition,
                                           wxDefaultSize, choices);
@@ -257,7 +260,8 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
 
             // Create the field wrapper
             std::unique_ptr<FieldWrapper> field(
-                (FieldWrapper *)new ListFieldWrapper((wxListBox *)choice));
+                (FieldWrapper *)new ListFieldWrapper((wxListBox *)choice,
+                                                     separator));
             idMap[meta.id] = std::move(field);
         }
 

--- a/espanso-modulo/src/sys/form/form.cpp
+++ b/espanso-modulo/src/sys/form/form.cpp
@@ -67,7 +67,18 @@ class ListFieldWrapper {
   public:
     explicit ListFieldWrapper(wxListBox *control) : control(control) {}
 
-    virtual wxString getValue() { return control->GetStringSelection(); }
+    virtual wxString getValue() {
+      wxArrayInt selections;
+      control->GetSelections(selections);
+
+      wxString value = "";
+      for (unsigned int i = 0; i < selections.size(); i++) {
+        if (i > 0) value.Append(", ");
+        value.Append(control->GetString(selections[i]));
+      }
+
+      return value;
+    }
 };
 
 // App Code

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -84,6 +84,7 @@ pub mod types {
         pub values: Vec<String>,
         pub choice_type: ChoiceType,
         pub default_value: String,
+        pub separator: String,
     }
 }
 
@@ -282,6 +283,7 @@ mod interop {
         values: Vec<CString>,
         values_ptr_array: Vec<*const c_char>,
         default_value: CString,
+        separator: CString,
         interop: Box<ChoiceMetadata>,
     }
 
@@ -310,16 +312,21 @@ mod interop {
             let default_value = CString::new(metadata.default_value)
                 .expect("unable to convert default value to CString");
 
+            let separator = CString::new(metadata.separator)
+                .expect("unable to convert separator to CString");
+
             let interop = Box::new(ChoiceMetadata {
                 values: values_ptr_array.as_ptr(),
                 valueSize: values.len() as c_int,
                 choiceType: choice_type,
                 defaultValue: default_value.as_ptr(),
+                separator: separator.as_ptr(),
             });
             Self {
                 values,
                 values_ptr_array,
                 default_value,
+                separator,
                 interop,
             }
         }

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -312,8 +312,8 @@ mod interop {
             let default_value = CString::new(metadata.default_value)
                 .expect("unable to convert default value to CString");
 
-            let separator = CString::new(metadata.separator)
-                .expect("unable to convert separator to CString");
+            let separator =
+                CString::new(metadata.separator).expect("unable to convert separator to CString");
 
             let interop = Box::new(ChoiceMetadata {
                 values: values_ptr_array.as_ptr(),

--- a/espanso-modulo/src/sys/interop/interop.h
+++ b/espanso-modulo/src/sys/interop/interop.h
@@ -46,6 +46,7 @@ typedef struct ChoiceMetadata {
     const int valueSize;
     const char *defaultValue;
     const ChoiceType choiceType;
+    const char *separator;
 } ChoiceMetadata;
 
 typedef struct FieldMetadata {

--- a/espanso-modulo/src/sys/interop/mod.rs
+++ b/espanso-modulo/src/sys/interop/mod.rs
@@ -52,6 +52,7 @@ pub struct ChoiceMetadata {
     pub valueSize: ::std::os::raw::c_int,
     pub defaultValue: *const ::std::os::raw::c_char,
     pub choiceType: ChoiceType,
+    pub separator: *const ::std::os::raw::c_char,
 }
 
 #[repr(C)]

--- a/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
@@ -80,7 +80,7 @@ fn convert_fields(fields: &Params) -> HashMap<String, FormField> {
                         .get("separator")
                         .and_then(|val| val.as_string())
                         .cloned()
-                        .unwrap_or(", ".to_string())
+                        .unwrap_or(", ".to_string()),
                 }),
                 // By default, it's considered type 'text'
                 _ => Some(FormField::Text {

--- a/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
@@ -76,6 +76,11 @@ fn convert_fields(fields: &Params) -> HashMap<String, FormField> {
                         .get("values")
                         .and_then(|v| extract_values(v, params.get("trim_string_values")))
                         .unwrap_or_default(),
+                    separator: params
+                        .get("separator")
+                        .and_then(|val| val.as_string())
+                        .cloned()
+                        .unwrap_or(", ".to_string())
                 }),
                 // By default, it's considered type 'text'
                 _ => Some(FormField::Text {

--- a/espanso/src/gui/mod.rs
+++ b/espanso/src/gui/mod.rs
@@ -57,6 +57,7 @@ pub enum FormField {
     List {
         default: Option<String>,
         values: Vec<String>,
+        separator: String,
     },
 }
 

--- a/espanso/src/gui/modulo/form.rs
+++ b/espanso/src/gui/modulo/form.rs
@@ -113,10 +113,15 @@ fn convert_fields_into_object(fields: &HashMap<String, FormField>) -> Map<String
               "default": default,
               "values": values,
             }),
-            FormField::List { default, values } => json!({
+            FormField::List {
+                default,
+                values,
+                separator,
+            } => json!({
               "type": "list",
               "default": default,
               "values": values,
+              "separator": separator,
             }),
         };
         obj.insert(name.clone(), value);


### PR DESCRIPTION
Allows multiple choices in the form list to be selected by holding **Ctrl** or **Shift**. By default, the selected items in the result will be joined by ", ", but this can be overridden in the YAML:

Usage:
```yaml
  - trigger: ":form"
    form: |
      [[choices]]
    form_fields:
      choices:
        type: list
        values:
          - First
          - Second
          - Third
        separator: "-"
```

Example output:
```
First-Third
```

Fixes #1199