### PR TITLE
Use wl-clipboard-rs for Wayland clipboard reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,15 +777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "downcast"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +962,7 @@ dependencies = [
  "thiserror 1.0.56",
  "wait-timeout",
  "widestring",
+ "wl-clipboard-rs",
 ]
 
 [[package]]
@@ -1221,6 +1213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1244,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1500,6 +1504,9 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1817,16 +1824,6 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "libloading"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
-dependencies = [
- "cfg-if 1.0.0",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2153,6 +2150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2397,17 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.4",
+ "indexmap 2.10.0",
+]
 
 [[package]]
 name = "phf"
@@ -2587,18 +2614,18 @@ checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -2993,12 +3020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,8 +3218,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-wlr 0.2.0",
  "wayland-scanner",
  "xkbcommon",
  "xkeysym",
@@ -3570,6 +3591,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3820,26 +3852,25 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.7"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.32",
- "scoped-tls",
+ "rustix 1.0.8",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.31.6"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.9.1",
- "rustix 0.38.32",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3879,6 +3910,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-wlr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,29 +3930,40 @@ dependencies = [
  "bitflags 2.9.1",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols",
+ "wayland-protocols 0.31.2",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.12",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.5"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.36.2",
+ "quick-xml 0.39.2",
  "quote",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.5"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
- "dlib",
- "log",
  "pkg-config",
 ]
 
@@ -4425,6 +4479,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.0.8",
+ "thiserror 2.0.12",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.12",
+ "wayland-protocols-wlr 0.3.12",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4440,7 +4512,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9a231574ae78801646617cefd13bfe94be907c0e4fa979cfd8b770aa3c5d08"
 dependencies = [
- "nom",
+ "nom 6.1.2",
 ]
 
 [[package]]

--- a/espanso-clipboard/Cargo.toml
+++ b/espanso-clipboard/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [features]
 # If the wayland feature is enabled, all X11 dependencies will be dropped
 # and wayland support will be enabled
-wayland = ["wait-timeout"]
+wayland = ["wait-timeout", "wl-clipboard-rs"]
 
 # If enabled, avoid linking with the gdiplus library on Windows, which
 # might conflict with wxWidgets
@@ -27,6 +27,7 @@ widestring.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wait-timeout = { version = "0.2.0", optional = true }
+wl-clipboard-rs = { version = "0.9.3", optional = true }
 
 [build-dependencies]
 cc.workspace = true

--- a/espanso-clipboard/src/lib.rs
+++ b/espanso-clipboard/src/lib.rs
@@ -92,17 +92,13 @@ pub fn get_clipboard(_: ClipboardOptions) -> Result<Box<dyn Clipboard>> {
 #[cfg(target_os = "linux")]
 #[cfg(feature = "wayland")]
 pub fn get_clipboard(options: ClipboardOptions) -> Result<Box<dyn Clipboard>> {
-    // TODO: On some Wayland compositors (currently sway), the "wlr-data-control" protocol
-    // could enable the use of a much more efficient implementation relying on the "wl-clipboard-rs" crate.
-    // Useful links: https://github.com/YaLTeR/wl-clipboard-rs/issues/8
-    //
-    // We could even decide the correct implementation at runtime by checking if the
-    // required protocol is available, if so use the efficient implementation
-    // instead of the fallback one, which calls the wl-copy and wl-paste binaries, and is thus
-    // less efficient
-
-    info!("using WaylandFallbackClipboard");
-    Ok(Box::new(wayland::fallback::WaylandFallbackClipboard::new(
-        options,
-    )?))
+    let fallback =
+        wayland::fallback::WaylandFallbackClipboard::new(options)?;
+    info!(
+        "using WaylandNativeClipboard (reads via wl-clipboard-rs, \
+         writes via wl-copy)"
+    );
+    Ok(Box::new(
+        wayland::native::WaylandNativeClipboard::new(fallback),
+    ))
 }

--- a/espanso-clipboard/src/wayland/mod.rs
+++ b/espanso-clipboard/src/wayland/mod.rs
@@ -18,3 +18,4 @@
  */
 
 pub(crate) mod fallback;
+pub(crate) mod native;

--- a/espanso-clipboard/src/wayland/native/mod.rs
+++ b/espanso-clipboard/src/wayland/native/mod.rs
@@ -1,0 +1,103 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::io::Read;
+
+use crate::{Clipboard, ClipboardOperationOptions};
+use log::error;
+use wl_clipboard_rs::paste;
+
+use super::fallback::WaylandFallbackClipboard;
+
+pub(crate) struct WaylandNativeClipboard {
+    fallback: WaylandFallbackClipboard,
+}
+
+impl WaylandNativeClipboard {
+    pub fn new(
+        fallback: WaylandFallbackClipboard,
+    ) -> Self {
+        Self { fallback }
+    }
+}
+
+impl Clipboard for WaylandNativeClipboard {
+    fn get_text(
+        &self,
+        _: &ClipboardOperationOptions,
+    ) -> Option<String> {
+        match paste::get_contents(
+            paste::ClipboardType::Regular,
+            paste::Seat::Unspecified,
+            paste::MimeType::Text,
+        ) {
+            Ok((mut pipe, _mime)) => {
+                let mut contents = String::new();
+                match pipe.read_to_string(&mut contents) {
+                    Ok(_) => Some(contents),
+                    Err(err) => {
+                        error!(
+                            "failed to read clipboard pipe: {}",
+                            err
+                        );
+                        None
+                    }
+                }
+            }
+            Err(
+                paste::Error::NoSeats
+                | paste::Error::ClipboardEmpty
+                | paste::Error::NoMimeType,
+            ) => None,
+            Err(err) => {
+                error!(
+                    "failed to get clipboard contents: {}",
+                    err
+                );
+                None
+            }
+        }
+    }
+
+    fn set_text(
+        &self,
+        text: &str,
+        options: &ClipboardOperationOptions,
+    ) -> anyhow::Result<()> {
+        self.fallback.set_text(text, options)
+    }
+
+    fn set_image(
+        &self,
+        image_path: &std::path::Path,
+        options: &ClipboardOperationOptions,
+    ) -> anyhow::Result<()> {
+        self.fallback.set_image(image_path, options)
+    }
+
+    fn set_html(
+        &self,
+        html: &str,
+        fallback_text: Option<&str>,
+        options: &ClipboardOperationOptions,
+    ) -> anyhow::Result<()> {
+        self.fallback
+            .set_html(html, fallback_text, options)
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `wl-paste` process spawning with `wl-clipboard-rs` for clipboard reads on Wayland. This avoids timeouts caused by `wl-paste` competing with other clipboard consumers for data-control protocol events from the compositor.
- Clipboard writes still use `wl-copy` for XWayland compatibility.

## Test plan

- [x] Tested espanso expansions in native Wayland apps
- [x] Tested espanso expansions in XWayland apps (Slack)
- [x] Verified `using WaylandNativeClipboard` appears in journal logs
- [x] Verified no `wl-paste has timed-out` errors after extended use

**Tested on:**
- Fedora 44
- COSMIC DE 1.0.9 (cosmic-comp 1.0.9, cosmic-session 1.0.9)
- Wayland 1.24.0
- wl-clipboard 2.2.1