### PR TITLE
feat: add label/id support for choice fields in forms #2627

### DIFF
--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -86,15 +86,79 @@ pub struct TextFieldConfig {
     pub multiline: bool,
 }
 
+/// A choice/list value. `Plain` means label and id are the same string;
+/// `LabelId` separates the display text (`label`) from the output value (`id`).
+#[derive(Debug, Serialize, Clone)]
+pub enum ChoiceValue {
+    Plain(String),
+    LabelId { label: String, id: String },
+}
+
+impl ChoiceValue {
+    pub fn label(&self) -> &str {
+        match self {
+            ChoiceValue::Plain(s) => s,
+            ChoiceValue::LabelId { label, .. } => label,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            ChoiceValue::Plain(s) => s,
+            ChoiceValue::LabelId { id, .. } => id,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ChoiceValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de;
+
+        struct ChoiceValueVisitor;
+
+        impl<'de> de::Visitor<'de> for ChoiceValueVisitor {
+            type Value = ChoiceValue;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a string or an object with 'id' and 'label'")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<ChoiceValue, E> {
+                Ok(ChoiceValue::Plain(v.to_owned()))
+            }
+
+            fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<ChoiceValue, M::Error> {
+                let mut id = None;
+                let mut label = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "id" => id = Some(map.next_value()?),
+                        "label" => label = Some(map.next_value()?),
+                        _ => { let _ = map.next_value::<serde::de::IgnoredAny>()?; }
+                    }
+                }
+                let id: String = id.ok_or_else(|| de::Error::missing_field("id"))?;
+                let label: String = label.ok_or_else(|| de::Error::missing_field("label"))?;
+                Ok(ChoiceValue::LabelId { label, id })
+            }
+        }
+
+        deserializer.deserialize_any(ChoiceValueVisitor)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ChoiceFieldConfig {
-    pub values: Vec<String>,
+    pub values: Vec<ChoiceValue>,
     pub default: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ListFieldConfig {
-    pub values: Vec<String>,
+    pub values: Vec<ChoiceValue>,
     pub default: String,
     pub separator: String,
 }
@@ -170,7 +234,7 @@ fn default_multiline() -> bool {
     false
 }
 
-fn default_values() -> Vec<String> {
+fn default_values() -> Vec<ChoiceValue> {
     Vec::new()
 }
 
@@ -190,7 +254,7 @@ pub struct AutoFieldConfig {
     pub multiline: bool,
 
     #[serde(default = "default_values")]
-    pub values: Vec<String>,
+    pub values: Vec<ChoiceValue>,
 
     #[serde(default = "default_separator")]
     pub separator: String,

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -17,7 +17,7 @@
  * along with modulo.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use super::config::{FieldConfig, FieldTypeConfig, FormConfig};
+use super::config::{ChoiceValue, FieldConfig, FieldTypeConfig, FormConfig};
 use super::parser::layout::Token;
 use crate::sys::form::types::{
     ChoiceMetadata, ChoiceType, Field, FieldType, Form, LabelMetadata, RowMetadata, TextMetadata,
@@ -27,6 +27,12 @@ use std::collections::HashMap;
 pub fn generate(config: FormConfig) -> Form {
     let structure = super::parser::layout::parse_layout(&config.layout);
     build_form(config, structure)
+}
+
+fn split_labels_ids(values: &[ChoiceValue]) -> (Vec<String>, Vec<String>) {
+    let labels = values.iter().map(|v| v.label().to_owned()).collect();
+    let ids = values.iter().map(|v| v.id().to_owned()).collect();
+    (labels, ids)
 }
 
 fn create_field(token: &Token, field_map: &HashMap<String, FieldConfig>) -> Field {
@@ -47,18 +53,26 @@ fn create_field(token: &Token, field_map: &HashMap<String, FieldConfig>) -> Fiel
                     default_text: config.default.clone(),
                     multiline: config.multiline,
                 }),
-                FieldTypeConfig::Choice(config) => FieldType::Choice(ChoiceMetadata {
-                    values: config.values.clone(),
-                    choice_type: ChoiceType::Dropdown,
-                    default_value: config.default.clone(),
-                    separator: String::new(),
-                }),
-                FieldTypeConfig::List(config) => FieldType::Choice(ChoiceMetadata {
-                    values: config.values.clone(),
-                    choice_type: ChoiceType::List,
-                    default_value: config.default.clone(),
-                    separator: config.separator.clone(),
-                }),
+                FieldTypeConfig::Choice(config) => {
+                    let (labels, ids) = split_labels_ids(&config.values);
+                    FieldType::Choice(ChoiceMetadata {
+                        values: labels,
+                        ids,
+                        choice_type: ChoiceType::Dropdown,
+                        default_value: config.default.clone(),
+                        separator: String::new(),
+                    })
+                }
+                FieldTypeConfig::List(config) => {
+                    let (labels, ids) = split_labels_ids(&config.values);
+                    FieldType::Choice(ChoiceMetadata {
+                        values: labels,
+                        ids,
+                        choice_type: ChoiceType::List,
+                        default_value: config.default.clone(),
+                        separator: config.separator.clone(),
+                    })
+                },
             };
 
             Field {

--- a/espanso-modulo/src/sys/form/form.cpp
+++ b/espanso-modulo/src/sys/form/form.cpp
@@ -232,7 +232,8 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
         for (int i = 0; i < choiceMeta->valueSize; i++) {
             choices.Add(wxString::FromUTF8(choiceMeta->values[i]));
 
-            if (strcmp(choiceMeta->values[i], choiceMeta->defaultValue) == 0) {
+            if (strcmp(choiceMeta->values[i], choiceMeta->defaultValue) == 0 ||
+                (choiceMeta->ids && strcmp(choiceMeta->ids[i], choiceMeta->defaultValue) == 0)) {
                 selectedItem = i;
             }
         }

--- a/espanso-modulo/src/sys/form/form.cpp
+++ b/espanso-modulo/src/sys/form/form.cpp
@@ -54,20 +54,32 @@ class TextFieldWrapper {
 
 class ChoiceFieldWrapper {
     wxChoice *control;
+    const char *const *ids;
+    int idCount;
 
   public:
-    explicit ChoiceFieldWrapper(wxChoice *control) : control(control) {}
+    explicit ChoiceFieldWrapper(wxChoice *control, const char *const *ids, int idCount)
+        : control(control), ids(ids), idCount(idCount) {}
 
-    virtual wxString getValue() { return control->GetStringSelection(); }
+    virtual wxString getValue() {
+        int sel = control->GetSelection();
+        if (ids && sel >= 0 && sel < idCount) {
+            return wxString::FromUTF8(ids[sel]);
+        }
+        return control->GetStringSelection();
+    }
 };
 
 class ListFieldWrapper {
     wxListBox *control;
     wxString separator;
+    const char *const *ids;
+    int idCount;
 
   public:
-    explicit ListFieldWrapper(wxListBox *control, wxString separator)
-        : control(control), separator(separator) {}
+    explicit ListFieldWrapper(wxListBox *control, wxString separator,
+                              const char *const *ids, int idCount)
+        : control(control), separator(separator), ids(ids), idCount(idCount) {}
 
     virtual wxString getValue() {
       wxArrayInt selections;
@@ -76,7 +88,12 @@ class ListFieldWrapper {
       wxString value = "";
       for (unsigned int i = 0; i < selections.size(); i++) {
         if (i > 0) value.Append(separator);
-        value.Append(control->GetString(selections[i]));
+        int sel = selections[i];
+        if (ids && sel >= 0 && sel < idCount) {
+            value.Append(wxString::FromUTF8(ids[sel]));
+        } else {
+            value.Append(control->GetString(sel));
+        }
       }
 
       return value;
@@ -236,7 +253,9 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
 
             // Create the field wrapper
             std::unique_ptr<FieldWrapper> field(
-                (FieldWrapper *)new ChoiceFieldWrapper((wxChoice *)choice));
+                (FieldWrapper *)new ChoiceFieldWrapper((wxChoice *)choice,
+                                                       choiceMeta->ids,
+                                                       choiceMeta->valueSize));
             idMap[meta.id] = std::move(field);
         } else {
             choice = (void *)new wxListBox(parent, wxID_ANY, wxDefaultPosition,
@@ -261,7 +280,9 @@ void FormFrame::AddComponent(wxPanel *parent, wxBoxSizer *sizer,
             // Create the field wrapper
             std::unique_ptr<FieldWrapper> field(
                 (FieldWrapper *)new ListFieldWrapper((wxListBox *)choice,
-                                                     separator));
+                                                     separator,
+                                                     choiceMeta->ids,
+                                                     choiceMeta->valueSize));
             idMap[meta.id] = std::move(field);
         }
 

--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -82,6 +82,7 @@ pub mod types {
     #[derive(Debug)]
     pub struct ChoiceMetadata {
         pub values: Vec<String>,
+        pub ids: Vec<String>,
         pub choice_type: ChoiceType,
         pub default_value: String,
         pub separator: String,
@@ -282,6 +283,8 @@ mod interop {
     struct OwnedChoiceMetadata {
         values: Vec<CString>,
         values_ptr_array: Vec<*const c_char>,
+        ids: Vec<CString>,
+        ids_ptr_array: Vec<*const c_char>,
         default_value: CString,
         separator: CString,
         interop: Box<ChoiceMetadata>,
@@ -295,6 +298,8 @@ mod interop {
 
     impl From<types::ChoiceMetadata> for OwnedChoiceMetadata {
         fn from(metadata: types::ChoiceMetadata) -> Self {
+            debug_assert_eq!(metadata.values.len(), metadata.ids.len(), "ChoiceMetadata: values and ids length mismatch");
+
             let values: Vec<CString> = metadata
                 .values
                 .into_iter()
@@ -303,6 +308,15 @@ mod interop {
 
             let values_ptr_array: Vec<*const c_char> =
                 values.iter().map(|value| value.as_ptr()).collect();
+
+            let ids: Vec<CString> = metadata
+                .ids
+                .into_iter()
+                .map(|id| CString::new(id).expect("unable to convert choice id to string"))
+                .collect();
+
+            let ids_ptr_array: Vec<*const c_char> =
+                ids.iter().map(|id| id.as_ptr()).collect();
 
             let choice_type = match metadata.choice_type {
                 types::ChoiceType::Dropdown => ChoiceType_DROPDOWN,
@@ -318,13 +332,16 @@ mod interop {
             let interop = Box::new(ChoiceMetadata {
                 values: values_ptr_array.as_ptr(),
                 valueSize: values.len() as c_int,
-                choiceType: choice_type,
                 defaultValue: default_value.as_ptr(),
+                choiceType: choice_type,
                 separator: separator.as_ptr(),
+                ids: ids_ptr_array.as_ptr(),
             });
             Self {
                 values,
                 values_ptr_array,
+                ids,
+                ids_ptr_array,
                 default_value,
                 separator,
                 interop,

--- a/espanso-modulo/src/sys/interop/interop.h
+++ b/espanso-modulo/src/sys/interop/interop.h
@@ -47,6 +47,7 @@ typedef struct ChoiceMetadata {
     const char *defaultValue;
     const ChoiceType choiceType;
     const char *separator;
+    const char *const *ids;
 } ChoiceMetadata;
 
 typedef struct FieldMetadata {

--- a/espanso-modulo/src/sys/interop/mod.rs
+++ b/espanso-modulo/src/sys/interop/mod.rs
@@ -53,6 +53,7 @@ pub struct ChoiceMetadata {
     pub defaultValue: *const ::std::os::raw::c_char,
     pub choiceType: ChoiceType,
     pub separator: *const ::std::os::raw::c_char,
+    pub ids: *const *const ::std::os::raw::c_char,
 }
 
 #[repr(C)]

--- a/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
@@ -23,9 +23,9 @@ use espanso_render::{
     extension::form::{FormProvider, FormProviderResult},
     Params, Value,
 };
-use log::error;
+use log::{error, warn};
 
-use crate::gui::{FormField, FormUI};
+use crate::gui::{ChoiceItem, FormField, FormUI};
 
 pub struct FormProviderAdapter<'a> {
     form_ui: &'a dyn FormUI,
@@ -106,7 +106,7 @@ fn convert_fields(fields: &Params) -> HashMap<String, FormField> {
     out
 }
 
-fn extract_values(value: &Value, trim_string_values: Option<&Value>) -> Option<Vec<String>> {
+fn extract_values(value: &Value, trim_string_values: Option<&Value>) -> Option<Vec<ChoiceItem>> {
     let trim_string_values = *trim_string_values
         .and_then(|v| v.as_bool())
         .unwrap_or(&true);
@@ -115,8 +115,21 @@ fn extract_values(value: &Value, trim_string_values: Option<&Value>) -> Option<V
         Value::Array(values) => Some(
             values
                 .iter()
-                .filter_map(|choice| choice.as_string())
-                .cloned()
+                .filter_map(|choice| match choice {
+                    Value::String(s) => Some(ChoiceItem::from(s.clone())),
+                    Value::Object(map) => {
+                        let id = map.get("id").and_then(|v| v.as_string()).cloned();
+                        let label = map.get("label").and_then(|v| v.as_string()).cloned();
+                        match (id, label) {
+                            (Some(id), Some(label)) => Some(ChoiceItem { id, label }),
+                            _ => {
+                                warn!("choice object missing 'id' or 'label', skipping: {:?}", map);
+                                None
+                            }
+                        }
+                    }
+                    _ => None,
+                })
                 .collect(),
         ),
         Value::String(values) => Some(
@@ -134,7 +147,7 @@ fn extract_values(value: &Value, trim_string_values: Option<&Value>) -> Option<V
                         Some(line)
                     }
                 })
-                .map(String::from)
+                .map(|s| ChoiceItem::from(String::from(s)))
                 .collect(),
         ),
         _ => None,

--- a/espanso/src/gui/mod.rs
+++ b/espanso/src/gui/mod.rs
@@ -44,6 +44,20 @@ pub trait FormUI {
     ) -> Result<Option<HashMap<String, String>>>;
 }
 
+/// A choice/list option. `label` is the text shown to the user;
+/// `id` is the value actually output when selected.
+#[derive(Debug, Clone)]
+pub struct ChoiceItem {
+    pub id: String,
+    pub label: String,
+}
+
+impl From<String> for ChoiceItem {
+    fn from(s: String) -> Self {
+        Self { id: s.clone(), label: s }
+    }
+}
+
 #[derive(Debug)]
 pub enum FormField {
     Text {
@@ -52,11 +66,11 @@ pub enum FormField {
     },
     Choice {
         default: Option<String>,
-        values: Vec<String>,
+        values: Vec<ChoiceItem>,
     },
     List {
         default: Option<String>,
-        values: Vec<String>,
+        values: Vec<ChoiceItem>,
         separator: String,
     },
 }

--- a/espanso/src/gui/modulo/form.rs
+++ b/espanso/src/gui/modulo/form.rs
@@ -99,6 +99,19 @@ struct ModuloFormConfig<'a> {
     max_form_height: usize,
 }
 
+fn choice_items_to_json(values: &[crate::gui::ChoiceItem]) -> Vec<Value> {
+    values
+        .iter()
+        .map(|item| {
+            if item.id == item.label {
+                json!(item.label)
+            } else {
+                json!({"id": item.id, "label": item.label})
+            }
+        })
+        .collect()
+}
+
 fn convert_fields_into_object(fields: &HashMap<String, FormField>) -> Map<String, Value> {
     let mut obj = Map::new();
     for (name, field) in fields {
@@ -108,21 +121,25 @@ fn convert_fields_into_object(fields: &HashMap<String, FormField>) -> Map<String
               "default": default,
               "multiline": multiline,
             }),
-            FormField::Choice { default, values } => json!({
-              "type": "choice",
-              "default": default,
-              "values": values,
-            }),
+            FormField::Choice { default, values } => {
+                json!({
+                  "type": "choice",
+                  "default": default,
+                  "values": choice_items_to_json(values),
+                })
+            }
             FormField::List {
                 default,
                 values,
                 separator,
-            } => json!({
-              "type": "list",
-              "default": default,
-              "values": values,
-              "separator": separator,
-            }),
+            } => {
+                json!({
+                  "type": "list",
+                  "default": default,
+                  "values": choice_items_to_json(values),
+                  "separator": separator,
+                })
+            }
         };
         obj.insert(name.clone(), value);
     }


### PR DESCRIPTION
### Description

Add label/id object support for choice fields in form mode. When a choice field uses `{label, id}` values, the dropdown displays the `label` text to the user but outputs the `id` value on selection.

Closes #2627

### Reasoning

The form path's choice field only accepted `Vec<String>`, so `{label, id}` objects were silently dropped during parsing, resulting in an empty dropdown. The fix threads a parallel `ids` array through the entire data pipeline:

- **YAML parsing** (`extract_values`): now handles `Value::Object({id, label})` alongside plain strings
- **Data model** (`ChoiceItem`, `ChoiceValue`): new types that carry both label and id
- **JSON serialization**: emits `{"id","label"}` objects when id ≠ label, plain strings otherwise (backward compatible)
- **Rust FFI** (`ChoiceMetadata`): added `ids: Vec<String>` field, converted to C pointer array
- **C/C++ UI** (`ChoiceFieldWrapper`, `ListFieldWrapper`): `getValue()` returns `ids[selectedIndex]` when ids is present, falls back to `GetStringSelection()` otherwise

Plain string configurations are unaffected — `From<String>` ensures id == label.

### Testing

1. Configure a form with a label/id choice field → trigger → verify dropdown shows labels
2. Select an option → verify the output text contains the id, not the label
3. Configure a form with plain string choice → trigger → verify behavior unchanged
4. Configure a form with both text field and label/id choice → verify both work
5. Configure a form with a label/id list field → verify multi-select returns ids joined by separator
6. Configure a choice with missing id or label in one entry → verify it is skipped with a warning log

### Type of change

:x: **Bug fix**
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change**
:x: **Refactor**
:x: **Performance**
:x: **Style**
:x: **Docs**
:x: **Chore**