### PR TITLE
Add description to desktop file

### DIFF
--- a/espanso/src/res/linux/espanso.desktop
+++ b/espanso/src/res/linux/espanso.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=Espanso
+Comment=Cross-platform Text Expander written in Rust
 Exec=espanso launcher
 Icon=icon
 Type=Application


### PR DESCRIPTION
Adds a description to the desktop file:

<img width="312" height="41" alt="image" src="https://github.com/user-attachments/assets/90f87960-8662-4b55-bb64-c5faf9c7d4cb" />
See [Recognized desktop entry keys](https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html)